### PR TITLE
[2] Prep to host via Jitpack

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,9 @@ buildscript {
 
         // Add the Crashlytics Gradle plugin.
         classpath 'com.google.firebase:firebase-crashlytics-gradle:2.0.0-beta03'
+
+        // Add the Android Maven plugin.
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
     }
 }
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,6 +1,9 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
+apply plugin: 'com.github.dcendents.android-maven'
+
+group='com.github.steamclock'
 
 android {
     compileSdkVersion 29


### PR DESCRIPTION
This PR includes the required updates to the root and lib build.gradle files in preparation for jitpack hosting.

After this is merged, I will make the repo public, add a release tag for v.0.1.0, and change our sample project to load the lib via jitpack.io.