### PR TITLE
Jitpack hosting support (#2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,5 +8,6 @@ The format is based on the Steamclock [Release Management Guide](https://github.
 - Added PR template (#21)
 - Added support for Sentry (#24)
 - Added readme (#16)
+- Attempting to use Jitpack (#2)
 
 ---

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,8 @@ buildscript {
         // For Sentry + Proguard/R8 support
         // https://github.com/getsentry/sentry-android-gradle-plugin/releases
         classpath 'io.sentry:sentry-android-gradle-plugin:1.7.35'
+
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
     }
 }
 

--- a/steamclog/build.gradle
+++ b/steamclog/build.gradle
@@ -1,6 +1,9 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
+//apply plugin: 'maven-publish'
+apply plugin: 'com.github.dcendents.android-maven'
+group='com.github.steamclock'
 
 //apply plugin: 'io.sentry.android.gradle'
 //apply plugin: 'com.google.firebase.crashlytics' // Firebase, Crashlytics
@@ -54,3 +57,31 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 }
+
+// https://developer.android.com/studio/build/maven-publish-plugin
+// Because the components are created only during the afterEvaluate phase, you must
+// configure your publications using the afterEvaluate() lifecycle method.
+//afterEvaluate {
+//    publishing {
+//        publications {
+//            // Creates a Maven publication called "release".
+//            release(MavenPublication) {
+//                // Applies the component for the release build variant.
+//                from components.release
+//
+//                // You can then customize attributes of the publication as shown below.
+//                groupId = 'com.steamclock.steamclog'
+//                //artifactId = 'final'
+//                version = android.defaultConfig.versionName
+//            }
+//            // Creates a Maven publication called “debug”.
+//            debug(MavenPublication) {
+//                // Applies the component for the debug build variant.
+//                from components.debug
+//                groupId = 'com.steamclock.steamclog'
+//                //artifactId = 'final-debug'
+//                version = android.defaultConfig.versionName
+//            }
+//        }
+//    }
+//}


### PR DESCRIPTION
### Related Issue: #2 


### Summary of Problem:
* We want to host this library in an easy to import fashion
* Jitpack seems to be the easiest way to do this

### Proposed Solution:
* Made repo public
* Following these steps: https://medium.com/@ome450901/publish-an-android-library-by-jitpack-a0342684cbd0
