### PR TITLE
Created initWith method that omits FirebaseAnalytics instance (#31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,6 @@ The format is based on the Steamclock [Release Management Guide](https://github.
 - Added support for Sentry (#24)
 - Added readme (#16)
 - Attempting to use Jitpack (#2)
+- Created initWith method that omits FirebaseAnalytics instance (#31)
 
 ---

--- a/steamclog/src/main/java/com/steamclock/steamclog/Steamclog.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/Steamclog.kt
@@ -70,6 +70,14 @@ object SteamcLog {
         }
     }
 
+    /** 
+     * initWith omitting FirebaseAnalytics instance, for applications that
+     * do not wish to use FirebaseAnalytics.
+     */
+    fun initWith(fileWritePath: File? = null) {
+        initWith(fileWritePath, null)
+    }
+
     //---------------------------------------------
     // Public Logging <level> calls
     //


### PR DESCRIPTION
### Related Issue: #31 


### Summary of Problem:
When integrating into a client project, we found that even if the application was not using FirebaseAnalytics, the application needed to include the library. 

### Proposed Solution:
Create second initWith method that does not require FirebaseAnalytics

### Testing Steps:
Will test on client 