### PR TITLE
Updated default LogLevelPresets (#33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on the Steamclock [Release Management Guide](https://github.com/steamclock/labs/wiki/Release-Management-Guide).
 
-## UNRELEASED
+## Unreleased 
+- Updated default LogLevelPresets (#33)
+
+
+---
+
+## Jitpack v1.1 : Sept 8th 2020
 - Added changelog! (#12)
 - Added PR template (#21)
 - Added support for Sentry (#24)

--- a/app/src/main/java/com/steamclock/steamclogsample/MainActivity.kt
+++ b/app/src/main/java/com/steamclock/steamclogsample/MainActivity.kt
@@ -31,6 +31,14 @@ class MainActivity : AppCompatActivity() {
         non_fatal.setOnClickListener { testNonFatal() }
         track_analytic.setOnClickListener { testTrackAnalytic() }
 
+        level_selector.setSelection(when (clog.config.logLevel) {
+            LogLevelPreset.Firehose -> 0
+            LogLevelPreset.Develop -> 1
+            LogLevelPreset.Release -> 2
+            LogLevelPreset.ReleaseAdvanced -> 3
+            else -> 0
+        })
+
         level_selector.onItemSelectedListener = object: AdapterView.OnItemSelectedListener {
             override fun onNothingSelected(parent: AdapterView<*>?) {}
 

--- a/steamclog/src/main/java/com/steamclock/steamclog/Config.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/Config.kt
@@ -18,7 +18,7 @@ data class Config(
     /**
      * Destination logging levels
      */
-    var logLevel: LogLevelPreset = LogLevelPreset.Develop,
+    var logLevel: LogLevelPreset = if (BuildConfig.DEBUG) LogLevelPreset.Firehose else LogLevelPreset.Release,
 
     /**
      *  Determines how long generated log files are kept for.
@@ -37,6 +37,15 @@ data class Config(
     var firebaseAnalytics: FirebaseAnalytics? = null
 ) {
     constructor(writeFilePath: File) : this(writeFilePath, firebaseAnalytics = null)
+
+    override fun toString(): String {
+        return "Config(" +
+                "\n  logLevel = $logLevel," +
+                "\n  fileWritePath = $fileWritePath," +
+                "\n  firebaseAnalytics = ${firebaseAnalytics}," +
+                "\n  keepLogsForDays = $keepLogsForDays," +
+                "\n  requireRedacted = $requireRedacted)"
+    }
 }
 
 

--- a/steamclog/src/main/java/com/steamclock/steamclog/LogLevelPreset.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/LogLevelPreset.kt
@@ -19,6 +19,14 @@ sealed class LogLevelPreset {
     /// Disk: none, system: none, remote: warn
     object Release: LogLevelPreset()
 
+    val title: String
+        get() = when(this) {
+            is Firehose -> "Firehose"
+            is Develop -> "Develop"
+            is ReleaseAdvanced -> "ReleaseAdvanced"
+            is Release -> "Release"
+        }
+
     val global: LogLevel
         get() = when(this) {
             is Firehose -> LogLevel.Info
@@ -68,6 +76,6 @@ sealed class LogLevelPreset {
         }
 
     override fun toString(): String {
-        return "DestinationLevels(global=$global, console=$console, file=$file, crashlytics=$crashlytics, sentry=$sentry)"
+        return "$title(global=$global, console=$console, file=$file, crashlytics=$crashlytics, sentry=$sentry)"
     }
 }

--- a/steamclog/src/main/java/com/steamclock/steamclog/Steamclog.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/Steamclog.kt
@@ -61,13 +61,13 @@ object SteamcLog {
         fileWritePath?.let {
             this.config = Config(fileWritePath)
             updateTree(externalLogFileTree, true)
-            info("Enabled External LogFile")
         }
 
         firebaseAnalytics?.let {
             clog.config.firebaseAnalytics = firebaseAnalytics
-            info("Enabled Analytics Reporting")
         }
+
+        info("Steamclog initialized:\n$this")
     }
 
     /** 


### PR DESCRIPTION
### Related Issue: #33


### Summary of Problem:
* I noticed while testing on a client project that I could never see all levels in the console when debugging
* Looking into it, we were defaulting the log level to always be "Develop", whereas iOS is using "Firehose"

### Proposed Solution:
* LogLevelPresets defaults are now -> DEBUG: **Firehose**, else: **Release** (matches iOS Readme).
* Added info message on sclog init to print out the config values for clarity.
* Updated sample app to not immediately overwrite the default log level.

### Testing Steps:
* Installed debug and release versions of the app, make sure the initial logLevel is as expected.
* On DEBUG build we can check the console, but on RELEASE I am printing out the Steamclog config to the activity for visibility.

**Debug**
![image](https://user-images.githubusercontent.com/5217641/94472798-1f72f000-0180-11eb-9ff0-e1e18805035c.png)
![image](https://user-images.githubusercontent.com/5217641/94472765-12560100-0180-11eb-97cf-20fadd522ad7.png)

**Release:** 
![image](https://user-images.githubusercontent.com/5217641/94472498-b3908780-017f-11eb-9930-1795f4c0d049.png)