### PR TITLE
Changed releaseAdvanced LogLevelPresets (#11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on the Steamclock [Release Management Guide](https://github.com/steamclock/labs/wiki/Release-Management-Guide).
 
+- Changed releaseAdvanced LogLevelPresets (#11)
+
+
 ## UNRELEASED
 - Added changelog! (#12)
 - Added PR template (#21)

--- a/steamclog/src/main/java/com/steamclock/steamclog/LogLevelPreset.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/LogLevelPreset.kt
@@ -31,7 +31,7 @@ sealed class LogLevelPreset {
         get() = when(this) {
             is Firehose -> LogLevel.None
             is Develop -> LogLevel.None
-            is ReleaseAdvanced -> LogLevel.Warn
+            is ReleaseAdvanced -> LogLevel.Info
             is Release -> LogLevel.Warn
         }
 


### PR DESCRIPTION
### Related Issue: #11 

### Summary of Problem:
* This came from a conversation from an internal project. Right now, by switching to SteamcLog, most of out Crashlytics logging is lost due to the higher logging level.

### Proposed Solution:
* Change level to info instead