### PR TITLE
Fixed default LogLevelPresets, app must now include debug info (#33);

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on the Steamclock [Release Management Guide](https://github.com/steamclock/labs/wiki/Release-Management-Guide).
 
 ## Unreleased 
+- Fixed default LogLevelPresets, app must now include debug info (#33)
+- Fixed crash on Pixel 4 devices running Android 11 (updated Sentry)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The `Steamclog.initWith` method can be used to enable external logging; this met
 
 To enable Steamclog to write to the device, you must specify where the files should be stored, this is most easily done by passing along the application's `externalCacheDir` or `cacheDir` references.
 ```
-clog.initWith(fileWritePath = externalCacheDir)
+clog.initWith(BuildConfig.DEBUG, fileWritePath = externalCacheDir)
 ```
  * See https://developer.android.com/training/data-storage for details on the pros and cons of each.
  
@@ -121,12 +121,12 @@ Due to current limitations on how the firebase plugin is applied to projects, yo
 The `Steamclog.initWith` method can be used to enable firebase analytics; this method only needs to be called once, and can be done in your Application object's `onCreate` method. If your application has setup Firebase Analytics correctly, the `Firebase.analytics` object should be available to be passed to the initWith method.
 
 ```
-clog.initWith(firebaseAnalytics = Firebase.analytics)
+clog.initWith(BuildConfig.DEBUG, firebaseAnalytics = Firebase.analytics)
 ```
 
 Both logging and analytics can be initialized at the same time:
 ```
-clog.initWith(fileWritePath = externalCacheDir, firebaseAnalytics = Firebase.analytics)
+clog.initWith(BuildConfig.DEBUG, fileWritePath = externalCacheDir, firebaseAnalytics = Firebase.analytics)
 ```
 
 ### Configuration

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -94,5 +94,5 @@ dependencies {
     implementation 'com.google.firebase:firebase-analytics-ktx:17.4.4'
 
     // https://github.com/getsentry/sentry-android/releases
-    implementation 'io.sentry:sentry-android:2.3.0'
+    implementation 'io.sentry:sentry-android:3.1.0'
 }

--- a/app/src/main/java/com/steamclock/steamclogsample/App.kt
+++ b/app/src/main/java/com/steamclock/steamclogsample/App.kt
@@ -1,8 +1,8 @@
 package com.steamclock.steamclogsample
 
 import android.app.Application
-import com.google.firebase.analytics.ktx.analytics
 import com.google.firebase.ktx.Firebase
+import com.google.firebase.analytics.ktx.analytics
 import com.steamclock.steamclog.clog
 
 /**
@@ -12,6 +12,6 @@ import com.steamclock.steamclog.clog
 class App: Application() {
     override fun onCreate() {
         super.onCreate()
-        clog.initWith(fileWritePath = externalCacheDir, firebaseAnalytics = Firebase.analytics)
+        clog.initWith(BuildConfig.DEBUG, fileWritePath = externalCacheDir, firebaseAnalytics = Firebase.analytics)
     }
 }

--- a/steamclog/src/main/java/com/steamclock/steamclog/Config.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/Config.kt
@@ -10,6 +10,13 @@ import java.io.File
  */
 data class Config(
     /**
+     * BuildConfig is tied to the module (ie. the Steamclog library module), so we cannot use it to determine
+     * a default logLevel as this will always be set to false when the library is being imported via JitPack.
+     * As such this info must be given to us by the application.
+     */
+    val isDebug: Boolean = false,
+
+    /**
      * Location where the app wishes to store any log files generated (ex. externalCacheDir)
      * Required on creation and will not change.
      */
@@ -18,7 +25,7 @@ data class Config(
     /**
      * Destination logging levels
      */
-    var logLevel: LogLevelPreset = if (BuildConfig.DEBUG) LogLevelPreset.Firehose else LogLevelPreset.Release,
+    var logLevel: LogLevelPreset = if (isDebug) LogLevelPreset.Firehose else LogLevelPreset.Release,
 
     /**
      *  Determines how long generated log files are kept for.
@@ -36,7 +43,7 @@ data class Config(
      */
     var firebaseAnalytics: FirebaseAnalytics? = null
 ) {
-    constructor(writeFilePath: File) : this(writeFilePath, firebaseAnalytics = null)
+    constructor(isDebug: Boolean, writeFilePath: File) : this(isDebug, writeFilePath, firebaseAnalytics = null)
 
     override fun toString(): String {
         return "Config(" +

--- a/steamclog/src/main/java/com/steamclock/steamclog/Steamclog.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/Steamclog.kt
@@ -57,9 +57,9 @@ object SteamcLog {
         // FirebaseAnalytics instance required before we can start tracking analytics
     }
 
-    fun initWith(fileWritePath: File? = null, firebaseAnalytics: FirebaseAnalytics? = null) {
+    fun initWith(isDebug: Boolean, fileWritePath: File? = null, firebaseAnalytics: FirebaseAnalytics? = null) {
         fileWritePath?.let {
-            this.config = Config(fileWritePath)
+            this.config = Config(isDebug, fileWritePath)
             updateTree(externalLogFileTree, true)
         }
 
@@ -74,8 +74,8 @@ object SteamcLog {
      * initWith omitting FirebaseAnalytics instance, for applications that
      * do not wish to use FirebaseAnalytics.
      */
-    fun initWith(fileWritePath: File? = null) {
-        initWith(fileWritePath, null)
+    fun initWith(isDebug: Boolean, fileWritePath: File? = null) {
+        initWith(isDebug, fileWritePath, null)
     }
 
     //---------------------------------------------


### PR DESCRIPTION
### Related Issue: #33 

### Summary of Problem:
* I was mistakenly using BuildConfig.DEBUG in the library module to set a default starting log level, failing to realize this will always reference the LIBRARY BuildConfig.
* This means that because an application uses a release version of Steamclog, the default was set to RELEASE even if the main application is a debug build.

### Proposed Solution:
* I could not find a way to reference the BuildConfig of the main application from the library, so we must have the calling application pass that info into the library during initialization
* Updated README to include new config option

NOTE, While attempting to verify this on my physical Pixel 4XL I ran into a crash that I fixed on this branch at the same time by updating the Sentry library 

This will introduce breaking changes for existing apps using Steamclog, but currently that's only a single project.

### Testing Steps:
Easiest to test using the sample app 
1. Build sample app as debug; when app launches, the log level dropdown should have automatically selected FIREHOSE
2. Build sample app as release; when app launches, the log level dropdown should have automatically selected RELEASE
