### PR TITLE
Update LogLevelPresets to default to release->info, releaseAdvanced->verbose (#45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on the Steamclock [Release Management Guide](https://github.
 ## Unreleased 
 
 - Update 3rd party libraries (#48)
+- Update LogLevelPresets to default to release->info, releaseAdvanced->verbose (#45)
+
 
 ---
 

--- a/steamclog/src/main/java/com/steamclock/steamclog/LogLevelPreset.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/LogLevelPreset.kt
@@ -39,16 +39,16 @@ sealed class LogLevelPreset {
         get() = when(this) {
             is Firehose -> LogLevel.None
             is Develop -> LogLevel.None
-            is ReleaseAdvanced -> LogLevel.Info
-            is Release -> LogLevel.Warn
+            is ReleaseAdvanced -> LogLevel.Verbose
+            is Release -> LogLevel.Info
         }
 
     val sentry: LogLevel
         get() = when(this) {
             is Firehose -> LogLevel.None
             is Develop -> LogLevel.None
-            is ReleaseAdvanced -> LogLevel.Info
-            is Release -> LogLevel.Warn
+            is ReleaseAdvanced -> LogLevel.Verbose
+            is Release -> LogLevel.Info
         }
 
     val file: LogLevel


### PR DESCRIPTION
### Related Issue: #45


### Summary of Problem:
Crash report logs do not contain enough logging information to be useful - by default they were only logging WARN and above, which are used very sparingly in our applications.

### Proposed Solution:
Update log level presets:
* release->info
* releaseAdvanced->verbose 