### PR TITLE
Improved control over crash report "title" (#51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on the Steamclock [Release Management Guide](https://github.com/steamclock/labs/wiki/Release-Management-Guide).
 
 ## Unreleased 
-
-- Update 3rd party libraries (#48)
 - Update LogLevelPresets to default to release->info, releaseAdvanced->verbose (#45)
-
+- Update 3rd party libraries (#48)
+- Clean up Sentry report formatting (#51)
 
 ---
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,7 +39,7 @@ android {
     buildTypes {
         debug {
             debuggable true
-            minifyEnabled true
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
         release {

--- a/app/src/main/java/com/steamclock/steamclogsample/MainActivity.kt
+++ b/app/src/main/java/com/steamclock/steamclogsample/MainActivity.kt
@@ -1,5 +1,8 @@
 package com.steamclock.steamclogsample
 
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
 import android.os.Bundle
 import android.view.View
 import android.widget.AdapterView
@@ -29,6 +32,10 @@ class MainActivity : AppCompatActivity() {
         dump_file_button.setOnClickListener { testLogDump() }
         non_fatal.setOnClickListener { testNonFatal() }
         track_analytic.setOnClickListener { testTrackAnalytic() }
+        demo_text.setOnLongClickListener {
+            copyFileToClipboard()
+            true
+        }
 
         level_selector.setSelection(when (clog.config.logLevel) {
             LogLevelPreset.Firehose -> 0
@@ -154,6 +161,14 @@ class MainActivity : AppCompatActivity() {
     private fun simulateCrash() {
         clog.info("Simulating a run time crash")
         throw RuntimeException("Test Crash") // Force a crash
+    }
+
+    private fun copyFileToClipboard() {
+        val clipboardManager = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+        val clipData = ClipData.newPlainText("File Dump", demo_text?.text)
+        clipboardManager.setPrimaryClip(clipData)
+        Toast.makeText(applicationContext, "Copied to clipboard", Toast.LENGTH_LONG).show()
+
     }
 
     // Test logging objects

--- a/app/src/main/java/com/steamclock/steamclogsample/MainActivity.kt
+++ b/app/src/main/java/com/steamclock/steamclogsample/MainActivity.kt
@@ -25,7 +25,7 @@ class MainActivity : AppCompatActivity() {
 
         // UI init
         demo_text.text = clog.toString()
-        log_things.setOnClickListener { testAllLoggingLevels() }
+        log_things.setOnClickListener { testLogging() }
         dump_file_button.setOnClickListener { testLogDump() }
         non_fatal.setOnClickListener { testNonFatal() }
         track_analytic.setOnClickListener { testTrackAnalytic() }
@@ -48,45 +48,98 @@ class MainActivity : AppCompatActivity() {
                 id: Long
             ) {
                 clog.config.logLevel = when (position) {
-                    0 -> LogLevelPreset.Firehose
-                    1 -> LogLevelPreset.Develop
-                    2 -> LogLevelPreset.Release
-                    3 -> LogLevelPreset.ReleaseAdvanced
-                    else -> LogLevelPreset.Firehose
+                    0 -> {
+                        LogLevelPreset.Firehose
+                    }
+                    1 -> {
+                        LogLevelPreset.Develop
+                    }
+                    2 -> {
+                        LogLevelPreset.Release
+                    }
+                    3 -> {
+                        LogLevelPreset.ReleaseAdvanced
+                    }
+                    else -> {
+                        LogLevelPreset.Firehose
+                    }
                 }
+                clog.warn("LogLevel changed to ${clog.config.logLevel.title}")
             }
         }
     }
 
-    private fun testAllLoggingLevels() {
-        clog.verbose("Verbose message")
-        clog.verbose("Verbose message", RedactableParent())
-
-        clog.debug("Debug message")
-        clog.debug("Debug message", RedactableParent())
-
-        clog.info("Info message")
-        clog.info("Info message", RedactableParent())
-
-        clog.warn("Warn message")
-        clog.warn("Warn message", RedactableParent())
-
+    private fun testLogging() {
+        testVerbose()
+        testDebug()
+        testWarn()
+        testInfo()
         Toast.makeText(applicationContext, "Logged some things! Check your console or show the dump the log.", Toast.LENGTH_LONG).show()
     }
 
+    private fun testVerbose() {
+        clog.verbose("Verbose message")
+        clog.verbose("Verbose message with data", RedactableParent())
+    }
+
+    private fun testDebug() {
+        clog.debug("Debug message")
+        clog.debug("Debug message with data", RedactableParent())
+    }
+
+    private fun testInfo() {
+        clog.info("Info message")
+        clog.info("Info message with data", RedactableParent())
+    }
+
+    private fun testWarn() {
+        clog.warn("Warn message")
+        clog.warn("Warn message with data", RedactableParent())
+    }
+
     private fun testNonFatal() {
-        clog.error("Error message")
-        clog.error("Error message", RedactableParent())
-        clog.error("Error message", Throwable("OriginalNonFatalThrowable"))
-        clog.error("Error message", Throwable("OriginalNonFatalThrowable"), RedactableParent())
+        // Won't create new tickets
+        clog.info("Running testNonFatal")
+
+        // Should create tickets
+        //
+        // NOTE, Sentry seems to apply some grouping logic such that the *same* Throwable thrown
+        // in the *same* function will be grouped no matter what messages they are given, such
+        // that the messages will overwrite each other.
+        //
+        // Since our examples are using the basic Throwable for testing, we need to call them in
+        // separate methods for testing, but in practice we shouldn't see this case since more
+        // unique Throwables will be used.
+        testNonFatalMessageOnly()
+        testNonFatalWithData()
+        testNonFatalWithThrowable()
+        testNonFatalWithThrowableAndData()
+    }
+
+    private fun testNonFatalMessageOnly() {
+        clog.error("Error with message only")
+    }
+
+    private fun testNonFatalWithData() {
+        clog.error("Error with Data", null, RedactableParent())
+    }
+
+    private fun testNonFatalWithThrowable() {
+        clog.error("Error with Throwable", Throwable("Error with Throwable"), null)
+    }
+
+    private fun testNonFatalWithThrowableAndData() {
+        clog.error("Error Throwable and Data", Throwable("Error with Throwable and Data"), RedactableParent())
     }
 
     private fun testFatalCrash() {
+        clog.info("Running testFatalCrash")
+
         // These will crash app
-            clog.fatal("Fatal message")
-//            clog.fatal("Fatal message", TestMe())
+            //clog.fatal("Fatal message")
+//            clog.fatal("Fatal message", RedactableParent())
 //            clog.fatal(Throwable("OriginalFatalThrowable"),"Fatal message")
-//            clog.fatal(Throwable("OriginalFatalThrowable"),"Fatal message", TestMe())
+            clog.fatal("Fatal message", Throwable("OriginalFatalThrowable"), RedactableParent())
     }
 
     private fun testTrackAnalytic() {
@@ -99,6 +152,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun simulateCrash() {
+        clog.info("Simulating a run time crash")
         throw RuntimeException("Test Crash") // Force a crash
     }
 

--- a/steamclog/build.gradle
+++ b/steamclog/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-analytics:18.0.2'
 
     // Add the Firebase Crashlytics SDK (not currently used in test app)
-    //implementation 'com.google.firebase:firebase-crashlytics:17.4.1'
+    implementation 'com.google.firebase:firebase-crashlytics:17.4.1'
 
     // https://github.com/getsentry/sentry-java/releases
     // Required so that we can reference the Sentry class

--- a/steamclog/src/main/java/com/steamclock/steamclog/Destinations.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/Destinations.kt
@@ -334,16 +334,13 @@ private fun generateSimpleLogMessage(priority: Int,
                                      throwable: Throwable?,
                                      defaultMessage: String): String {
 
-    val emoji = if (includeEmoji) {
-        "${LogLevel.getLogLevel(priority)?.emoji} "
-    } else {
-        ""
-    }
+    val emoji = LogLevel.getLogLevel(priority)?.emoji
+    val emojiStr = if (includeEmoji && emoji != null) { "$emoji " } else { "" }
 
     val wrapper = SteamclogThrowableWrapper.from(throwable)
     val extraData = wrapper?.extraData?.let { ": $it" } ?: run { "" }
     val originalMessage = wrapper?.originalMessage ?: defaultMessage
-    return "$emoji$originalMessage$extraData"
+    return "$emojiStr$originalMessage$extraData"
 }
 
 /**

--- a/steamclog/src/main/java/com/steamclock/steamclog/Destinations.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/Destinations.kt
@@ -185,7 +185,7 @@ internal class ExternalLogFileDestination : Timber.DebugTree() {
             val appId = BuildConfig.LIBRARY_PACKAGE_NAME
             val processId = android.os.Process.myPid()
             val threadName = Thread.currentThread().name
-            val logStr = "$logTimeStamp $appId[$processId:$threadName] [$priority] [$tag] > $message"
+            val logStr = "$logTimeStamp $appId[$processId:$threadName] [$priority] [$tag] > $message \r\n"
             // If file created or exists save logs
             getExternalFile()?.let { file -> file.appendText(logStr) }
         } catch (e: Exception) {

--- a/steamclog/src/main/java/com/steamclock/steamclog/Destinations.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/Destinations.kt
@@ -208,7 +208,7 @@ internal class ExternalLogFileDestination : Timber.DebugTree() {
      */
     private fun printLogToExternalFile(message: String) {
         try {
-            getExternalFile()?.let { file -> file.appendText(message) }
+            getExternalFile()?.let { file -> file.appendText("$message\r\n") }
         } catch (e: Exception) {
             logToConsole("HTMLFileTree failed to write into file: $e")
         }

--- a/steamclog/src/main/java/com/steamclock/steamclog/Destinations.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/Destinations.kt
@@ -170,13 +170,6 @@ internal class ExternalLogFileDestination : Timber.DebugTree() {
     }
 
     //---------------------------------------------
-    // Reformats console output to include file and line number to log.
-    //---------------------------------------------
-//    override fun createStackElementTag(element: StackTraceElement): String? {
-//        return "(${element.fileName}:${element.lineNumber}):${element.methodName}"
-//    }
-
-    //---------------------------------------------
     // Allows us to print out to an external file if desired.
     //---------------------------------------------
     override fun log(priority: Int, tag: String?, message: String, throwable: Throwable?) {

--- a/steamclog/src/main/java/com/steamclock/steamclog/LogLevelPreset.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/LogLevelPreset.kt
@@ -32,7 +32,7 @@ sealed class LogLevelPreset {
             is Firehose -> LogLevel.Info
             is Develop -> LogLevel.Info
             is ReleaseAdvanced -> LogLevel.Info
-            is Release -> LogLevel.Warn
+            is Release -> LogLevel.Info
         }
 
     val crashlytics: LogLevel

--- a/steamclog/src/main/java/com/steamclock/steamclog/Steamclog.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/Steamclog.kt
@@ -4,6 +4,7 @@ package com.steamclock.steamclog
 
 import android.os.Bundle
 import android.os.Parcelable
+import android.util.Log
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import org.jetbrains.annotations.NonNls
@@ -67,7 +68,7 @@ object SteamcLog {
             clog.config.firebaseAnalytics = firebaseAnalytics
         }
 
-        info("Steamclog initialized:\n$this")
+        logInternal(LogLevel.Info, "Steamclog initialized:\n$this")
     }
 
     /** 
@@ -119,12 +120,12 @@ object SteamcLog {
 
     fun track(@NonNls id: String, data: Map<String, Any?>) {
         if (!config.logLevel.analyticsEnabled) {
-            info("Anayltics not enabled ($id)")
+            logInternal(LogLevel.Info, "Anayltics not enabled ($id)")
             return
         }
 
         if (config.firebaseAnalytics == null) {
-            info("Firebase analytics instance not set ($id)")
+            logInternal(LogLevel.Info, "Firebase analytics instance not set ($id)")
             return
         }
 
@@ -195,6 +196,15 @@ object SteamcLog {
             is Throwable -> "$message ${obj.message?.let { throwMsg ->" : $throwMsg"}}"
             else -> "$message : ${obj.getRedactedDescription()}"
         }
+    }
+
+    /**
+     * Allows the Steamclog library to log info messages.
+     * Due to stacktrace manipultions being done in the Destinations, we should not call
+     * the info/debug/verbose calls directly.
+     */
+    private fun logInternal(priority: LogLevel, message: String) {
+        logTimber(priority, message, null, null)
     }
 
     /**

--- a/steamclog/src/main/java/com/steamclock/steamclog/Steamclog.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/Steamclog.kt
@@ -89,35 +89,32 @@ object SteamcLog {
     // To get around this for now we explicit versions of each <level> method below without optional
     // parameters.
     //---------------------------------------------
-    fun verbose(@NonNls message: String)                = logTimber(LogLevel.Verbose, message)
-    fun verbose(@NonNls message: String, obj: Any)      = logTimber(LogLevel.Verbose, message, obj)
+    fun verbose(@NonNls message: String)                = logTimber(LogLevel.Verbose, message, null, null)
+    fun verbose(@NonNls message: String, obj: Any)      = logTimber(LogLevel.Verbose, message, null, obj)
 
-    fun debug(@NonNls message: String)                  = logTimber(LogLevel.Debug, message)
-    fun debug(@NonNls message: String, obj: Any)        = logTimber(LogLevel.Debug, message, obj)
+    fun debug(@NonNls message: String)                  = logTimber(LogLevel.Debug, message, null, null)
+    fun debug(@NonNls message: String, obj: Any)        = logTimber(LogLevel.Debug, message, null, obj)
 
-    fun info(@NonNls message: String)                   = logTimber(LogLevel.Info, message)
-    fun info(@NonNls message: String, obj: Any)         = logTimber(LogLevel.Info, message, obj)
+    fun info(@NonNls message: String)                   = logTimber(LogLevel.Info, message, null, null)
+    fun info(@NonNls message: String, obj: Any)         = logTimber(LogLevel.Info, message, null, obj)
 
-    fun warn(@NonNls message: String)                   = logTimber(LogLevel.Warn, message)
-    fun warn(@NonNls message: String, obj: Any)         = logTimber(LogLevel.Warn, message, obj)
+    fun warn(@NonNls message: String)                   = logTimber(LogLevel.Warn, message, null, null)
+    fun warn(@NonNls message: String, obj: Any)         = logTimber(LogLevel.Warn, message, null, obj)
 
-    fun error(@NonNls message: String)                  = logTimber(LogLevel.Error, message)
-    fun error(@NonNls message: String, obj: Any)        = logTimber(LogLevel.Error, message, obj)
+    fun error(@NonNls message: String)                  = logTimber(LogLevel.Error, message, null, null)
     fun error(@NonNls message: String, throwable: Throwable?, obj: Any?) = logTimber(LogLevel.Error, message, throwable, obj)
 
-    fun fatal(@NonNls message: String)                  = logTimber(LogLevel.Fatal, message)
-    fun fatal(@NonNls message: String, obj: Any)        = logTimber(LogLevel.Fatal, message, obj)
+    fun fatal(@NonNls message: String)                  = logTimber(LogLevel.Fatal, message, null, null)
     fun fatal(@NonNls message: String, throwable: Throwable?, obj: Any?) = logTimber(LogLevel.Fatal, message, throwable, obj)
 
-    // Mapping onto the corresponding Timber calls.
-    private fun logTimber(logLevel: LogLevel, @NonNls message: String) = Timber.log(logLevel.javaLevel, message)
-    private fun logTimber(logLevel: LogLevel, @NonNls message: String, throwable: Throwable?, obj: Any?) = Timber.log(logLevel.javaLevel, throwable, addObjToMessage(message, obj))
-    private fun logTimber(logLevel: LogLevel, @NonNls message: String, obj: Any?) {
-        if (obj is Throwable) {
-            Timber.log(logLevel.javaLevel, obj, message)
-        } else {
-            Timber.log(logLevel.javaLevel, addObjToMessage(message, obj))
-        }
+    /**
+     *  Since Timber logging allows a Thowable to be passed to its trees, we wrap all data in
+     *  a SteamclogThrowableWrapper, and let the Destinations handle the data components accordingly.
+     */
+    private fun logTimber(logLevel: LogLevel, @NonNls message: String, throwable: Throwable?, obj: Any?) {
+        val extraData =  obj?.getRedactedDescription()
+        val wrapper = SteamclogThrowableWrapper(message, throwable, extraData)
+        Timber.log(logLevel.javaLevel, wrapper)
     }
 
     fun track(@NonNls id: String, data: Map<String, Any?>) {

--- a/steamclog/src/main/java/com/steamclock/steamclog/SteamclogThrowableWrapper.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/SteamclogThrowableWrapper.kt
@@ -1,0 +1,12 @@
+package com.steamclock.steamclog
+
+/**
+ * SteamclogThrowableWrapper
+ * Enables multiple types of data to be passed to our Destinations.
+ *
+ * Created by shayla on 2020-09-28
+ */
+data class SteamclogThrowableWrapper(
+    val originalMessage: String,
+    val originalThrowable: Throwable?,
+    val extraData: String?): Throwable(originalMessage)

--- a/steamclog/src/main/java/com/steamclock/steamclog/SteamclogThrowableWrapper.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/SteamclogThrowableWrapper.kt
@@ -9,4 +9,16 @@ package com.steamclock.steamclog
 data class SteamclogThrowableWrapper(
     val originalMessage: String,
     val originalThrowable: Throwable?,
-    val extraData: String?): Throwable(originalMessage)
+    val extraData: String?): Throwable(originalMessage)  {
+        companion object {
+            fun from(throwable: Throwable?): SteamclogThrowableWrapper? {
+                if (throwable == null) return null
+                return throwable as? SteamclogThrowableWrapper
+                    ?: SteamclogThrowableWrapper(
+                        throwable.message ?: throwable.toString(),
+                        originalThrowable = throwable,
+                        extraData = null
+                    )
+            }
+        }
+}


### PR DESCRIPTION
### Related Issue: #51 


### Summary of Problem:
When Sentry support was added, we bumped into a situation where the report being made had a title that included the extra data string; this caused the list of reports to become very hard to read.
![image](https://user-images.githubusercontent.com/5217641/114778600-ea984600-9d29-11eb-99f7-083ec07c5210.png)

This PR fixes those formatting issues and forces extra data to be written as logs/breadcrumbs on crash reports

### Proposed Solution:
* Created a class that can encapsulate the message, original throwable and any extra data that should be written to the logs.
* Each Destination is responsible for determining how best to include all of these objects.
* Crash reporting Destinations no longer include the "extra" (Redactable) data in the log titles.

### Testing Steps:
I checked the output of each Destination to be sure it looked correct:

**Sentry:**
![Screen Shot 2021-04-14 at 1 30 54 PM](https://user-images.githubusercontent.com/5217641/114778958-58dd0880-9d2a-11eb-9ec8-394a22ccd9a1.png)
Breadcrumbs showing messages and extra data:
![image](https://user-images.githubusercontent.com/5217641/114920308-27257980-9dde-11eb-972e-58a397b249c7.png)

**Crashlytics (although this is now deprecated in favour of Sentry):**
![Screen Shot 2021-04-14 at 1 28 07 PM](https://user-images.githubusercontent.com/5217641/114778990-61cdda00-9d2a-11eb-882a-aadc561c51cf.png)
Logs showing messages and extra data:
![image](https://user-images.githubusercontent.com/5217641/114779141-96419600-9d2a-11eb-8a17-cd81d46b5e06.png)

**File:** 
![image](https://user-images.githubusercontent.com/5217641/114921727-bb441080-9ddf-11eb-91ff-2eb0b4155b32.png)

**Console:**
![image](https://user-images.githubusercontent.com/5217641/114921887-e464a100-9ddf-11eb-9404-2d7c73a9f094.png)
