### PR TITLE
Fixed Proguard/R8 crash occurring on Debug builds (#67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on the Steamclock [Release Management Guide](https://github.com/steamclock/labs/wiki/Release-Management-Guide).
 
 ## Unreleased 
-
+- Fixed Proguard/R8 crash occurring on Debug builds (#67)
 
 ---
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,7 +35,7 @@ android {
 
     buildTypes {
         debug {
-            debuggable false
+            debuggable true
             minifyEnabled true // Always minify so that we can test proguard
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }

--- a/steamclog/consumer-rules.pro
+++ b/steamclog/consumer-rules.pro
@@ -1,8 +1,8 @@
-# Required if you want to use Steamclog Redactable classes, and Proguard/R8 to obsfucate code.
+## Required if you want to use Steamclog Redactable classes, and Proguard/R8 to obsfucate code.
 -keep class * extends com.steamclock.steamclog.Redactable { *; }
-
-# Sample specific
 -keep public class * { # All public classes
     public static *; # All public static fields in those classes
     public protected abstract *(...); # All public or protected abstract methods in those classes
 }
+
+-keep,allowoptimization class com.steamclock.steamclog.* { *; }

--- a/steamclog/consumer-rules.pro
+++ b/steamclog/consumer-rules.pro
@@ -1,8 +1,9 @@
-# Required if you want to use Steamclog Redactable classes, and Proguard/R8 to obsfucate code.
+## Required if you want to use Steamclog Redactable classes, and Proguard/R8 to obsfucate code.
 -keep class * extends com.steamclock.steamclog.Redactable { *; }
 -keep public class * { # All public classes
     public static *; # All public static fields in those classes
     public protected abstract *(...); # All public or protected abstract methods in those classes
 }
 
+# Required for run time verfication that CustomStackElementTag is correct
 -keep,allowoptimization class com.steamclock.steamclog.* { *; }

--- a/steamclog/consumer-rules.pro
+++ b/steamclog/consumer-rules.pro
@@ -1,4 +1,4 @@
-## Required if you want to use Steamclog Redactable classes, and Proguard/R8 to obsfucate code.
+# Required if you want to use Steamclog Redactable classes, and Proguard/R8 to obsfucate code.
 -keep class * extends com.steamclock.steamclog.Redactable { *; }
 -keep public class * { # All public classes
     public static *; # All public static fields in those classes


### PR DESCRIPTION
### Related Issue: #67 


### Summary of Problem:
Not sure how it happened, but during my last round of development I disabled debugging on the sample app - I also added some run time checks on Debug builds to make sure that the custom stack trace being generated had the correct index. This check was actually failing when Proguard was being applied (due to a method name change), but because I had disabled debugging, I did not catch it on the sample app.

### Proposed Solution:
Updated proguard rules to keep all method names; I don't see the harm in having those exposed.

### Testing Steps:
* Run debug build of sample app -> App should not crash! (this was happening originally)
* Log things -> App should not crash
* Send non-fatals -> App should not crash
* Check Sentry -> Logs should be created with readable stacktraces
![image](https://user-images.githubusercontent.com/5217641/118899431-9271d800-b8c3-11eb-9252-d7a2d879164c.png)
