### PR TITLE
Added ability to suppress specific Throwables from ever being logged as an error (#22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on the Steamclock [Release Management Guide](https://github.com/steamclock/labs/wiki/Release-Management-Guide).
 
 ## Unreleased 
-- Added config.blockedThrowables to allow specific Throwables/Exceptions to be suppressed from being sent as an error to the crash reporting destination (#22)
+- Added ThrowableBlocker functional interface to allow specific Throwables/Exceptions to be suppressed from being sent as an error to the crash reporting destination (#22)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on the Steamclock [Release Management Guide](https://github.com/steamclock/labs/wiki/Release-Management-Guide).
 
 ## Unreleased 
-
+- Added config.blockedThrowables to allow specific Throwables/Exceptions to be suppressed from being sent as an error to the crash reporting destination (#22)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Error and Fatal levels have a special signature that allows a given Throwable to
 `clog.<level>(_ message: String, throwable: Throwable,  object: Any)`
 
 If no `Throwable` object is given for an error or fatal log, Steamclog will create a generic `NonFatalException` instance that will be used to generate crash reports on Sentry.
-Please note, an error will only be logged if the Throwable is _not_ in the `config.blockedThrowables` set.
+Please note, an error will only be logged if the Throwable is _not_ in the blocked via the `ThrowableBlocker` interface implementation.
 
 ### Exporting Logs
 

--- a/README.md
+++ b/README.md
@@ -7,23 +7,24 @@
 An open source library that consolidates/formalizes the logging setup and usage across all of Steamclock's projects.
 
 ## Table of Contents
-  * [Development](#development)
-    + [Deploying new versions](#deploying-new-versions)
-  * [Usage](#usage)
-    + [Installation](#installation)
-    + [Initialization](#initialization)
-      - [Enabling External File Logging](#enabling-external-file-logging)
-    + [Enabling Sentry Reporting](#enabling-sentry-reporting)
-      - [Enabling Firebase Crashlytics (No longer supported)](#enabling-firebase-crashlytics--no-longer-supported-)
-      - [Enabling Firebase Analytics (No longer supported)](#enabling-firebase-analytics--no-longer-supported-)
-    + [Configuration](#configuration)
-      - [logLevel: LogLevelPreset](#loglevel--loglevelpreset)
-      - [requireRedacted: Bool](#requireredacted--bool)
-    + [Common methods](#common-methods)
-      - [Basic Signatures](#basic-signatures)
-      - [Error and Fatal Specific Signatures](#error-and-fatal-specific-signatures)
-    + [Exporting Logs](#exporting-logs)
-      - [Variable Redaction](#variable-redaction)
+- [Development](#development)
+  * [Deploying new versions](#deploying-new-versions)
+- [Usage](#usage)
+  * [Installation](#installation)
+  * [Initialization](#initialization)
+    + [Enabling External File Logging](#enabling-external-file-logging)
+    + [Setting up a Throwable/Exception "Block List"](#setting-up-a-throwable-exception--block-list-)
+  * [Enabling Sentry Reporting](#enabling-sentry-reporting)
+    + [Enabling Firebase Crashlytics (No longer supported)](#enabling-firebase-crashlytics--no-longer-supported-)
+    + [Enabling Firebase Analytics (No longer supported)](#enabling-firebase-analytics--no-longer-supported-)
+  * [Configuration](#configuration)
+    + [logLevel: LogLevelPreset](#loglevel--loglevelpreset)
+    + [requireRedacted: Bool](#requireredacted--bool)
+  * [Common methods](#common-methods)
+    + [Basic Signatures](#basic-signatures)
+    + [Error and Fatal Specific Signatures](#error-and-fatal-specific-signatures)
+  * [Exporting Logs](#exporting-logs)
+    + [Variable Redaction](#variable-redaction)
 
 <small><i><a href='http://ecotrust-canada.github.io/markdown-toc/'>Table of contents generated with markdown-toc</a></i></small>
 
@@ -95,6 +96,19 @@ clog.initWith(BuildConfig.DEBUG, fileWritePath = externalCacheDir)
 ```
  * See https://developer.android.com/training/data-storage for details on the pros and cons of each.
  
+ #### Setting up a Throwable/Exception "Block List"
+ If you'd like to suppress a Throwable or Exception from _ever_ being logged as an error in your crash reporting system, the `initWith` method also takes a parameter that defines a set of classes that should not be logged as errors. This is most commonly done to avoid common network connection exceptions from being logged as actionable errors. By default this set is empty, and all Throwables will be logged as errors.
+ 
+ This can be setup during initialization:
+ ```
+ val blockedExceptions: MutableSet<KClass<out Throwable>> = mutableSetOf(BlockedException1::class, BlockedException2::class)
+ clog.initWith(BuildConfig.DEBUG, externalCacheDir, blockedExceptions)
+ ```
+ 
+ or at a later time by accessing the config object directly:
+ ```
+ clog.config.blockedThrowables.add(BlockedException1::class)
+ ```
  
 ### Enabling Sentry Reporting 
 
@@ -160,6 +174,7 @@ Error and Fatal levels have a special signature that allows a given Throwable to
 `clog.<level>(_ message: String, throwable: Throwable,  object: Any)`
 
 If no `Throwable` object is given for an error or fatal log, Steamclog will create a generic `NonFatalException` instance that will be used to generate crash reports on Sentry.
+Please note, an error will only be logged if the Throwable is _not_ in the `config.blockedThrowables` set.
 
 ### Exporting Logs
 

--- a/app/src/main/java/com/steamclock/steamclogsample/App.kt
+++ b/app/src/main/java/com/steamclock/steamclogsample/App.kt
@@ -1,9 +1,8 @@
 package com.steamclock.steamclogsample
 
 import android.app.Application
-import com.steamclock.steamclog.ThrowableFilter
+import com.steamclock.steamclog.ThrowableBlocker
 import com.steamclock.steamclog.clog
-import kotlin.reflect.KClass
 
 /**
  * steamclog
@@ -13,7 +12,7 @@ class App: Application() {
     override fun onCreate() {
         super.onCreate()
         clog.initWith(BuildConfig.DEBUG, externalCacheDir)
-        clog.throwableFilter = ThrowableFilter { throwable ->
+        clog.throwableBlocker = ThrowableBlocker { throwable ->
             when (throwable) {
                 is BlockedException1 -> {
                     true

--- a/app/src/main/java/com/steamclock/steamclogsample/App.kt
+++ b/app/src/main/java/com/steamclock/steamclogsample/App.kt
@@ -1,9 +1,8 @@
 package com.steamclock.steamclogsample
 
 import android.app.Application
+import com.steamclock.steamclog.ThrowableFilter
 import com.steamclock.steamclog.clog
-import java.io.IOException
-import java.lang.Exception
 import kotlin.reflect.KClass
 
 /**
@@ -13,8 +12,20 @@ import kotlin.reflect.KClass
 class App: Application() {
     override fun onCreate() {
         super.onCreate()
-        val blocked: MutableSet<KClass<out Throwable>> = mutableSetOf(BlockedException1::class, BlockedException2::class)
-        clog.initWith(BuildConfig.DEBUG, externalCacheDir, blocked)
+        clog.initWith(BuildConfig.DEBUG, externalCacheDir)
+        clog.throwableFilter = ThrowableFilter { throwable ->
+            when (throwable) {
+                is BlockedException1 -> {
+                    true
+                }
+                is BlockedException2 -> {
+                    true
+                }
+                else -> {
+                    false
+                }
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/steamclock/steamclogsample/App.kt
+++ b/app/src/main/java/com/steamclock/steamclogsample/App.kt
@@ -2,6 +2,9 @@ package com.steamclock.steamclogsample
 
 import android.app.Application
 import com.steamclock.steamclog.clog
+import java.io.IOException
+import java.lang.Exception
+import kotlin.reflect.KClass
 
 /**
  * steamclog
@@ -10,6 +13,11 @@ import com.steamclock.steamclog.clog
 class App: Application() {
     override fun onCreate() {
         super.onCreate()
-        clog.initWith(BuildConfig.DEBUG, fileWritePath = externalCacheDir)
+        val blocked: MutableSet<KClass<out Throwable>> = mutableSetOf(BlockedException1::class, BlockedException2::class)
+        clog.initWith(BuildConfig.DEBUG, externalCacheDir, blocked)
     }
 }
+
+class BlockedException1(message: String): Exception(message)
+class BlockedException2(message: String): Exception(message)
+class AllowedException(message: String): Exception(message)

--- a/app/src/main/java/com/steamclock/steamclogsample/MainActivity.kt
+++ b/app/src/main/java/com/steamclock/steamclogsample/MainActivity.kt
@@ -76,6 +76,7 @@ class MainActivity : AppCompatActivity() {
                         LogLevelPreset.Firehose
                     }
                 }
+                demo_text.text = clog.toString()
                 clog.warn("LogLevel changed to ${clog.config.logLevel.title}")
             }
         }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -113,10 +113,14 @@
                 android:text="Set UserId (1234)"
                 android:layout_gravity="center"/>
 
-            <View
+            <Button
+                style="@style/Widget.AppCompat.Button.Colored"
+                android:id="@+id/log_blocked_exception"
                 android:layout_width="0dp"
                 android:layout_weight="1"
-                android:layout_height="0dp" />
+                android:layout_height="wrap_content"
+                android:text="Log Blocked Exception"
+                android:layout_gravity="center"/>
 
         </LinearLayout>
 

--- a/steamclog/src/main/java/com/steamclock/steamclog/Config.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/Config.kt
@@ -1,6 +1,7 @@
 package com.steamclock.steamclog
 
 import java.io.File
+import kotlin.reflect.KClass
 
 /**
  * Config
@@ -22,6 +23,12 @@ data class Config(
     val fileWritePath: File? = null,
 
     /**
+     * The set of Throwable (& classes that extend Throwable, like Exception) that will
+     * be blocked from being sent as errors to the crash reporting destination.
+     */
+    val blockedThrowables: MutableSet<KClass<out Throwable>> = mutableSetOf(),
+
+    /**
      * Destination logging levels
      */
     var logLevel: LogLevelPreset = if (isDebug) LogLevelPreset.Firehose else LogLevelPreset.Release,
@@ -34,15 +41,17 @@ data class Config(
     /**
      * Indicates if objects being logged must implement the redacted interface.
      */
-    var requireRedacted: Boolean = false,
+    var requireRedacted: Boolean = false
 
 ) {
     override fun toString(): String {
         return "Config(" +
                 "\n  logLevel = $logLevel," +
                 "\n  fileWritePath = $fileWritePath," +
+                "\n  blockedThrowables = ${blockedThrowables.map { it.simpleName }}, " +
                 "\n  keepLogsForDays = $keepLogsForDays," +
                 "\n  requireRedacted = $requireRedacted)"
+
     }
 }
 

--- a/steamclog/src/main/java/com/steamclock/steamclog/Config.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/Config.kt
@@ -1,7 +1,6 @@
 package com.steamclock.steamclog
 
 import java.io.File
-import kotlin.reflect.KClass
 
 /**
  * Config
@@ -23,12 +22,6 @@ data class Config(
     val fileWritePath: File? = null,
 
     /**
-     * The set of Throwable (& classes that extend Throwable, like Exception) that will
-     * be blocked from being sent as errors to the crash reporting destination.
-     */
-    val blockedThrowables: MutableSet<KClass<out Throwable>> = mutableSetOf(),
-
-    /**
      * Destination logging levels
      */
     var logLevel: LogLevelPreset = if (isDebug) LogLevelPreset.Firehose else LogLevelPreset.Release,
@@ -48,7 +41,6 @@ data class Config(
         return "Config(" +
                 "\n  logLevel = $logLevel," +
                 "\n  fileWritePath = $fileWritePath," +
-                "\n  blockedThrowables = ${blockedThrowables.map { it.simpleName }}, " +
                 "\n  keepLogsForDays = $keepLogsForDays," +
                 "\n  requireRedacted = $requireRedacted)"
 

--- a/steamclog/src/main/java/com/steamclock/steamclog/Destinations.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/Destinations.kt
@@ -52,8 +52,9 @@ internal class SentryDestination : Timber.Tree() {
 
         when {
             priority == Log.ERROR && originalThrowable != null -> {
-                // We have been given a throwable, if not in the blocked list, capture it.
-                if (SteamcLog.config.blockedThrowables.contains(originalThrowable::class)) {
+                // Check to see if we want to allow or block the Throwable from being reported
+                // as an error.
+                if (SteamcLog.throwableFilter.shouldBlock(originalThrowable)) {
                     Sentry.addBreadcrumb("${originalThrowable::class.simpleName} on blocked list, and has " +
                             "been blocked from being captured as an exception: " +
                             "${originalThrowable.message}", breadcrumbCategory)

--- a/steamclog/src/main/java/com/steamclock/steamclog/Destinations.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/Destinations.kt
@@ -54,7 +54,7 @@ internal class SentryDestination : Timber.Tree() {
             priority == Log.ERROR && originalThrowable != null -> {
                 // Check to see if we want to allow or block the Throwable from being reported
                 // as an error.
-                if (SteamcLog.throwableFilter.shouldBlock(originalThrowable)) {
+                if (SteamcLog.throwableBlocker.shouldBlock(originalThrowable)) {
                     Sentry.addBreadcrumb("${originalThrowable::class.simpleName} on blocked list, and has " +
                             "been blocked from being captured as an exception: " +
                             "${originalThrowable.message}", breadcrumbCategory)

--- a/steamclog/src/main/java/com/steamclock/steamclog/Destinations.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/Destinations.kt
@@ -301,6 +301,7 @@ private fun generateFullLogMessage(priority: Int,
  * Used mostly for Steamclog to report message using Log (not Timber), since using
  * Timber may lead to infinite calls in the library.
  */
+@SuppressLint("LogNotTimber")
 internal fun logToConsole(message: String) {
     Log.v("steamclog", message)
 }

--- a/steamclog/src/main/java/com/steamclock/steamclog/Steamclog.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/Steamclog.kt
@@ -7,7 +7,6 @@ import io.sentry.protocol.User
 import org.jetbrains.annotations.NonNls
 import timber.log.Timber
 import java.io.File
-import kotlin.reflect.KClass
 
 /**
  * Steamclog
@@ -39,7 +38,7 @@ object SteamcLog {
      * Can be overridden by the application to allow Throwables to be filtered out before
      * being sent as errors to the crash reporting destination.
      */
-    var throwableFilter: ThrowableFilter = ThrowableFilter { false } // By default filter nothing
+    var throwableBlocker: ThrowableBlocker = ThrowableBlocker { false } // By default filter nothing
 
     init {
         // By default plant all trees; setting their level to LogLevel.None will effectively

--- a/steamclog/src/main/java/com/steamclock/steamclog/Steamclog.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/Steamclog.kt
@@ -7,6 +7,7 @@ import io.sentry.protocol.User
 import org.jetbrains.annotations.NonNls
 import timber.log.Timber
 import java.io.File
+import kotlin.reflect.KClass
 
 /**
  * Steamclog
@@ -48,9 +49,11 @@ object SteamcLog {
         // Don't plant yet; fileWritePath required before we can start writing to ExternalLogFileDestination
     }
 
-    fun initWith(isDebug: Boolean, fileWritePath: File? = null) {
+    fun initWith(isDebug: Boolean,
+                 fileWritePath: File? = null,
+                 blockedThrowables: MutableSet<KClass<out Throwable>> = mutableSetOf()) {
         fileWritePath?.let {
-            this.config = Config(isDebug, fileWritePath)
+            this.config = Config(isDebug, fileWritePath, blockedThrowables)
             updateTree(externalLogFileTree, true)
         }
 

--- a/steamclog/src/main/java/com/steamclock/steamclog/Steamclog.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/Steamclog.kt
@@ -35,6 +35,12 @@ object SteamcLog {
     var config: Config = Config()
         private set
 
+    /**
+     * Can be overridden by the application to allow Throwables to be filtered out before
+     * being sent as errors to the crash reporting destination.
+     */
+    var throwableFilter: ThrowableFilter = ThrowableFilter { false } // By default filter nothing
+
     init {
         // By default plant all trees; setting their level to LogLevel.None will effectively
         // disable that tree, but we do not uproot it.
@@ -50,10 +56,9 @@ object SteamcLog {
     }
 
     fun initWith(isDebug: Boolean,
-                 fileWritePath: File? = null,
-                 blockedThrowables: MutableSet<KClass<out Throwable>> = mutableSetOf()) {
+                 fileWritePath: File? = null) {
         fileWritePath?.let {
-            this.config = Config(isDebug, fileWritePath, blockedThrowables)
+            this.config = Config(isDebug, fileWritePath)
             updateTree(externalLogFileTree, true)
         }
 

--- a/steamclog/src/main/java/com/steamclock/steamclog/ThrowableBlocker.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/ThrowableBlocker.kt
@@ -1,11 +1,11 @@
 package com.steamclock.steamclog
 
 /**
- * ThrowableFilter functional interface (ie. should only contain a single method).
+ * ThrowableBlocker functional interface (ie. should only contain a single method).
  * Allows the application to intercept Throwables when an error occurs and decide if the
  * Throwable should be blocked from being logged as an error by the crash reporting
  * destination.
  */
-fun interface ThrowableFilter {
+fun interface ThrowableBlocker {
     fun shouldBlock(throwable: Throwable): Boolean
 }

--- a/steamclog/src/main/java/com/steamclock/steamclog/ThrowableFilter.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/ThrowableFilter.kt
@@ -1,0 +1,11 @@
+package com.steamclock.steamclog
+
+/**
+ * ThrowableFilter functional interface (ie. should only contain a single method).
+ * Allows the application to intercept Throwables when an error occurs and decide if the
+ * Throwable should be blocked from being logged as an error by the crash reporting
+ * destination.
+ */
+fun interface ThrowableFilter {
+    fun shouldBlock(throwable: Throwable): Boolean
+}


### PR DESCRIPTION
### Related Issue: #22


### Summary of Problem:
* On a few projects now, we have seen network connection issues (IOExceptions) being constantly logged as errors to the crash reporting destination, when in fact these are not actual "error" situations. This causes the Sentry issue list to become messy, and requires overhead from the developers to determine that the issue should be closed.
* We want a way to suppress specific Throwables/Exceptions from ever being logged as an error.

### Proposed Solution:
~~* Config setup now includes a `blockedThrowables` set of classes; the crash reporting destination will check this set, and only log an issue if the Throwable it is given is *not* in the list of blocked classes. A breadcrumb has been added to indicate that this suppression has occurred (we can totally change the message, I came up with it quickly).~~
* Added ThrowableBlocker interface that allows each application to handle a throwable/exception before it is going to be logged to the crash reporting destination and decide if it should be blocked from actually being logged.
* Updated sample app to allow us to test this.
* Updated README with config steps

### Testing Steps:
1. Run sample app
2. Change log level to RELEASE
3. Hit the "Log Blocked Exception" button
4. Check Sentry project for the sample app (https://sentry.io/organizations/steamclock-software/issues/?project=5399932&statsPeriod=14d) and make sure that the only issue logged is for the `AllowedException`:
![image](https://user-images.githubusercontent.com/5217641/129793308-89de3c03-cf67-40cf-a74b-fe0aee68fddb.png)
5. Click into the issue and verify that the breadcrumb log does contain information about the BlockedExceptions:
![image](https://user-images.githubusercontent.com/5217641/129793433-647677c2-d5b9-485b-baa6-6fbbed3939cd.png)
