### PR TITLE
[78] Use latest Sentry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on the Steamclock [Release Management Guide](https://github.
 
 ## Unreleased 
 
+- Update Sentry from 4.3.0 to 5.1.0
+
 
 ---
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,27 +48,22 @@ android {
 
 // Defaults taken directly from https://docs.sentry.io/platforms/android/
 sentry {
-    // Disables or enables the automatic configuration of ProGuard
-    // for Sentry.  This injects a default config for ProGuard so
-    // you don't need to do it manually.
-    autoProguardConfig true
-
     // Enables or disables the automatic upload of mapping files
     // during a build.  If you disable this, you'll need to manually
     // upload the mapping files with sentry-cli when you do a release.
-    autoUpload true
+    autoUpload = true
 
     // Disables or enables the automatic configuration of Native Symbols
     // for Sentry. This executes sentry-cli automatically so
     // you don't need to do it manually.
     // Default is disabled.
-    uploadNativeSymbols false
+    uploadNativeSymbols = false
 
     // Does or doesn't include the source code of native code for Sentry.
     // This executes sentry-cli with the --include-sources param. automatically so
     // you don't need to do it manually.
     // Default is disabled.
-    includeNativeSources false
+    includeNativeSources = false
 }
 
 dependencies {
@@ -86,6 +81,6 @@ dependencies {
     implementation project(':steamclog')
 
     // https://github.com/getsentry/sentry-java/releases
-    implementation 'io.sentry:sentry-android:4.3.0'
+    implementation 'io.sentry:sentry-android:5.1.0'
 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -10,16 +10,15 @@ buildscript {
     dependencies {
         classpath "com.android.tools.build:gradle:4.1.3"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
-
-        // For Sentry + Proguard/R8 support
-        // https://github.com/getsentry/sentry-android-gradle-plugin/releases
-        classpath 'io.sentry:sentry-android-gradle-plugin:1.7.36'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
+}
+
+plugins {
+    id "io.sentry.android.gradle" version "2.1.1"
 }
 
 allprojects {

--- a/steamclog/build.gradle
+++ b/steamclog/build.gradle
@@ -19,8 +19,8 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 30
-        versionCode 1
-        versionName "1.0"
+        versionCode 2
+        versionName "1.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/steamclog/build.gradle
+++ b/steamclog/build.gradle
@@ -51,7 +51,7 @@ dependencies {
 
     // https://github.com/getsentry/sentry-java/releases
     // Required so that we can reference the Sentry class
-    implementation 'io.sentry:sentry-android:4.3.0'
+    implementation 'io.sentry:sentry-android:5.1.0'
 
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 }


### PR DESCRIPTION
### Related Issue: #78

### Summary of Problem:
We should use the newest Sentry SDK to minimize chances of problems in reporting.

### Proposed Solution:
- Updated various Sentry version markers
- Removed `autoProguardConfig` and updated syntax (needed the equal signs now)
  - see https://docs.sentry.io/platforms/android/migration/
- Bumped version of Steamclog (not sure if this is done right 🤔)