### PR TITLE
[1] Add log file rotation functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on the Steamclock [Release Management Guide](https://github.
 ## Unreleased 
 - Added ThrowableBlocker functional interface to allow specific Throwables/Exceptions to be suppressed from being sent as an error to the crash reporting destination (#22)
 - Update Sentry from 4.3.0 to 5.1.0
+- [1] Add log rotation functionality 
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -91,8 +91,9 @@ Out of the box, Steamclog will have support for
 The `Steamclog.initWith` method can be used to enable external logging; this method only needs to be called once, and can be done in your Application object's `onCreate` method.
 
 To enable Steamclog to write to the device, you must specify where the files should be stored, this is most easily done by passing along the application's `externalCacheDir` or `cacheDir` references.
+You can specify how long one file will be used for between rotations using `fileRotationSeconds`. The default value is 600 seconds, or 10 minutes.
 ```
-clog.initWith(BuildConfig.DEBUG, fileWritePath = externalCacheDir)
+clog.initWith(BuildConfig.DEBUG, fileWritePath = externalCacheDir, fileRotationSeconds = 600)
 ```
  * See https://developer.android.com/training/data-storage for details on the pros and cons of each.
  

--- a/steamclog/src/main/java/com/steamclock/steamclog/AutoRotateConfig.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/AutoRotateConfig.kt
@@ -9,5 +9,9 @@ data class AutoRotateConfig(
     /**
      * The number of seconds before a log file is rotated
      */
-    val fileRotationSeconds: Long = 600 // matching iOS
-)
+    val fileRotationSeconds: Long = defaultFileRotationSeconds // matching iOS
+) {
+    companion object {
+        const val defaultFileRotationSeconds = 600L
+    }
+}

--- a/steamclog/src/main/java/com/steamclock/steamclog/AutoRotateConfig.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/AutoRotateConfig.kt
@@ -1,0 +1,13 @@
+package com.steamclock.steamclog
+
+/**
+ * Config
+ *
+ * Created by jake on 2021-09-01
+ */
+data class AutoRotateConfig(
+    /**
+     * The number of seconds before a log file is rotated
+     */
+    val fileRotationSeconds: Long = 600 // matching iOS
+)

--- a/steamclog/src/main/java/com/steamclock/steamclog/Config.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/Config.kt
@@ -32,6 +32,11 @@ data class Config(
     var keepLogsForDays: Int = 3,
 
     /**
+     *  Configuration for auto-rotating file behaviour
+     */
+    var autoRotateConfig: AutoRotateConfig = AutoRotateConfig(),
+
+    /**
      * Indicates if objects being logged must implement the redacted interface.
      */
     var requireRedacted: Boolean = false

--- a/steamclog/src/main/java/com/steamclock/steamclog/Destinations.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/Destinations.kt
@@ -160,7 +160,7 @@ internal class ExternalLogFileDestination : Timber.DebugTree() {
     }
 
     private fun getExternalFile(): File? {
-        val expiryMs = SteamcLog.config.autoRotateConfig.fileRotationSeconds * 1000 // (defaults to 10 minutes
+        val expiryMs = SteamcLog.config.autoRotateConfig.fileRotationSeconds * 1000 // defaults to 10 minutes
 
         if (isCachedLogFileValid(expiryMs)) {
             return cachedCurrentLogFile

--- a/steamclog/src/main/java/com/steamclock/steamclog/Destinations.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/Destinations.kt
@@ -230,7 +230,7 @@ internal class ExternalLogFileDestination : Timber.DebugTree() {
     internal suspend fun getLogFileContents(): String? {
         removeOldLogFiles()
         val logBuilder = StringBuilder()
-        getExternalLogDirectory()?.listFiles()?.forEach { file ->
+        getExternalLogDirectory()?.listFiles()?.sortedBy { it.lastModified() }?.forEach { file ->
             try {
                 logToConsole("Reading file ${file.name}")
                 // This method is not recommended on huge files. It has an internal limitation of 2 GB file size.

--- a/steamclog/src/main/java/com/steamclock/steamclog/Destinations.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/Destinations.kt
@@ -174,7 +174,6 @@ internal class ExternalLogFileDestination : Timber.DebugTree() {
     private fun isCachedLogFileValid(expiryMs: Long): Boolean {
         // if you have a cached log file and you checked it within the expiry window
         val now = Date().time
-        val cachedCurrentLogFile = cachedCurrentLogFile
         val currentLogFileCachedTime = currentLogFileCachedTime
         return cachedCurrentLogFile != null &&
                 currentLogFileCachedTime != null &&

--- a/steamclog/src/main/java/com/steamclock/steamclog/Destinations.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/Destinations.kt
@@ -106,7 +106,7 @@ internal class ExternalLogFileDestination : Timber.DebugTree() {
     private var fileNamePrefix: String = "sclog"
     private var fileExt = "txt"
 
-    private var rotatingIndexes = (0 until 10).map { it }
+    private var rotatingIndexes = List(10) { it }
 
     private var cachedCurrentLogFile: File? = null
     private var currentLogFileCachedTime: Long? = null

--- a/steamclog/src/main/java/com/steamclock/steamclog/Steamclog.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/Steamclog.kt
@@ -55,9 +55,10 @@ object SteamcLog {
     }
 
     fun initWith(isDebug: Boolean,
-                 fileWritePath: File? = null) {
+                 fileWritePath: File? = null,
+                 fileRotationSeconds: Long? = null) {
         fileWritePath?.let {
-            this.config = Config(isDebug, fileWritePath)
+            this.config = Config(isDebug, fileWritePath, autoRotateConfig = AutoRotateConfig(fileRotationSeconds ?: AutoRotateConfig.defaultFileRotationSeconds))
             updateTree(externalLogFileTree, true)
         }
 

--- a/steamclog/src/main/java/com/steamclock/steamclog/Steamclog.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/Steamclog.kt
@@ -56,9 +56,9 @@ object SteamcLog {
 
     fun initWith(isDebug: Boolean,
                  fileWritePath: File? = null,
-                 fileRotationSeconds: Long? = null) {
+                 fileRotationSeconds: Long = AutoRotateConfig.defaultFileRotationSeconds) {
         fileWritePath?.let {
-            this.config = Config(isDebug, fileWritePath, autoRotateConfig = AutoRotateConfig(fileRotationSeconds ?: AutoRotateConfig.defaultFileRotationSeconds))
+            this.config = Config(isDebug, fileWritePath, autoRotateConfig = AutoRotateConfig(fileRotationSeconds))
             updateTree(externalLogFileTree, true)
         }
 


### PR DESCRIPTION
### Related Issue: #1

### Summary of Problem:
Android didn't support the log file rotation like iOS

### Proposed Solution:
Add log rotation functionality. Note that this doesn't work exactly the same as iOS because we don't have a method for accessing the creation date of a file. Instead, we used the last-modified date to determine if the file should be rotated.

With the default value of 10 minutes, this will only differ from iOS in the case where the app is open and is logging for a full 10 minutes. At that point, iOS would rotate the log file, where as Android wouldn't rotate until 10 after the last write. In both cases, the most likely scenario for a rotation is in between app launches though.

The rules for selecting a log file on Android are:
If any of the log files was last edited within the configured expiry time, use that file
Otherwise, use the first empty log file
If no empty or unexpired log file exists, clear the oldest one and use that instead

I've also implemented some caching to try to prevent performance issues caused by finding the correct log file each time.

### Testing Steps:
1. Clear all log files on the device using Android Studio's Device File Explorer (for my emulator, the files were in `/storage/emulated/0/Android/data/com.steamclock.steamclogsample/cache/logs`
2. Set the rotation time before logging anything to a low value (I used 5 seconds) in code
3. Wait X number of seconds (where X is your log rotation time) then tap the "Log Things" button in the app
4. Repeat the previous step 5 times
5. Ensure you have the correct number of log files in your log directory (should be one for the app starting, then one more for each "Log Things" button tap)
7. Repeat steps 3 and 4 again.
8. Ensure you have log files 0 - 9, and that the log files were correctly rotated based on the max of 10 files (ie: log file 11 should be log file 1, so it should have later logs than log file 5)
9. Tap "Show File Dump" and ensure logs are printed out in the correct order (by log time, and not file index)

### Screenshots:
N/A