### PR TITLE
Fixed issue with Sentry/Proguard plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on the Steamclock [Release Management Guide](https://github.
 - Added ThrowableBlocker functional interface to allow specific Throwables/Exceptions to be suppressed from being sent as an error to the crash reporting destination (#22)
 - Update Sentry from 4.3.0 to 5.1.0
 - [1] Add log rotation functionality 
+- Fixed issue with Sentry/Proguard plugin
 
 ---
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,8 +4,8 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'io.sentry.android.gradle' // Sentry Proguard/R8 mappings
 
 repositories {
-    jcenter()
     mavenCentral()
+    jcenter() // Deprecated
 }
 
 android {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
-
 apply plugin: 'io.sentry.android.gradle' // Sentry Proguard/R8 mappings
 
 repositories {
     jcenter()
+    mavenCentral()
 }
 
 android {
@@ -81,6 +81,5 @@ dependencies {
     implementation project(':steamclog')
 
     // https://github.com/getsentry/sentry-java/releases
-    implementation 'io.sentry:sentry-android:5.1.0'
-
+    implementation 'io.sentry:sentry-android:5.1.2'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -11,14 +11,8 @@ buildscript {
         classpath "com.android.tools.build:gradle:4.1.3"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
-
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
+        classpath 'io.sentry:sentry-android-gradle-plugin:2.1.0'
     }
-}
-
-plugins {
-    id "io.sentry.android.gradle" version "2.1.1"
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.4.21"
+    ext.kotlin_version = "1.5.20"
     repositories {
         google()
         jcenter()
@@ -18,7 +18,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        jcenter() // Deprecated
     }
 }
 


### PR DESCRIPTION
### Summary of Problem:
* Appears to be an issue with the recent changes for setting up Sentry
* Plugin responsible for auto uploading of mapping was not being loaded correctly, appeared to try and fall back to command line tool that is not installed by default
* Our gradle version is very old, did not support the plugin syntax recommended on the Sentry documentation.

### Proposed Solution:
Converting the build files back to the old method of plugin import (`apply plugin: 'io.sentry.android.gradle') appeared to fix the issue. Looking into updating to use the most recent version of gradle, but there's a bunch of breaking changes I need to work through. If I cannot solve them fast enough we can use this PR as a stop gap to get the recent changes out and released.

I also updated the Sentry version again since it was already out of date.

### Testing Steps:
1. Build sample app (make sure it builds)
2. Change log level to RELEASE
3. Send non fatals
4. Check Sentry and make sure the most recent reports have function names in the stack trace:
![image](https://user-images.githubusercontent.com/5217641/132779170-356f8158-81a8-4b14-9565-cfa0243fc63a.png)