### PR TITLE
Update gradle version and clean up gradle files (#86)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on the Steamclock [Release Management Guide](https://github.
 - Added ThrowableBlocker functional interface to allow specific Throwables/Exceptions to be suppressed from being sent as an error to the crash reporting destination (#22)
 - Update Sentry from 4.3.0 to 5.1.0
 - [1] Add log rotation functionality 
+- Updated to Gradle 7.0; updated 3rd party libraries (#86)
 
 ---
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,16 +1,19 @@
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+}
 
-apply plugin: 'io.sentry.android.gradle' // Sentry Proguard/R8 mappings
-
-repositories {
-    jcenter()
+plugins {
+    id 'com.android.application'
+    id 'kotlin-android'
+    id 'kotlin-android-extensions'
+    id 'io.sentry.android.gradle' version '2.1.4'
 }
 
 android {
     compileSdkVersion 30
-    buildToolsVersion "29.0.3"
+    buildToolsVersion "30.0.3"
 
     // ADD COMPATIBILITY OPTIONS TO BE COMPATIBLE WITH JAVA 1.8
     // Added for Sentry support
@@ -68,19 +71,19 @@ sentry {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
-    implementation 'com.google.android.material:material:1.3.0'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.0'
+    implementation 'com.google.android.material:material:1.4.0'
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2-native-mt'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.2-native-mt'
 
     implementation project(':steamclog')
 
     // https://github.com/getsentry/sentry-java/releases
-    implementation 'io.sentry:sentry-android:5.1.0'
+    implementation 'io.sentry:sentry-android:5.1.2'
 
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,6 +8,7 @@ plugins {
     id 'com.android.application'
     id 'kotlin-android'
     id 'kotlin-android-extensions'
+    // Provides auto-uploading of proguard mappings to Sentry
     id 'io.sentry.android.gradle' version '2.1.4'
 }
 
@@ -70,20 +71,14 @@ sentry {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.3.1'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.0'
-    implementation 'com.google.android.material:material:1.4.0'
-    testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    implementation project(':steamclog')
+    // Since Sentry is a dependency of steamclog, we do not have to import it again
 
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2-native-mt'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.2-native-mt'
 
-    implementation project(':steamclog')
-
-    // https://github.com/getsentry/sentry-java/releases
-    implementation 'io.sentry:sentry-android:5.1.2'
-
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation 'androidx.appcompat:appcompat:1.3.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.0'
+    implementation 'com.google.android.material:material:1.4.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.4.21"
+    ext.kotlin_version = '1.5.20'
     repositories {
         google()
         jcenter()
@@ -8,17 +8,11 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:4.1.3"
+        classpath 'com.android.tools.build:gradle:7.0.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
-
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
-}
-
-plugins {
-    id "io.sentry.android.gradle" version "2.1.1"
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = '1.5.20'
+    ext.kotlin_version = '1.5.30'
+    ext.timber = '5.0.1'
+    ext.sentry = '5.1.2'
+
     repositories {
         google()
-        jcenter()
         mavenCentral()
+        jcenter() // Deprecated
     }
 
     dependencies {
@@ -18,7 +21,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        jcenter() // Deprecated
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 07 14:04:56 PDT 2021
+#Thu Sep 09 17:36:08 PDT 2021
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/steamclog/build.gradle
+++ b/steamclog/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 android {
     compileSdkVersion 30
-    buildToolsVersion "29.0.3"
+    buildToolsVersion "30.0.3"
 
     // ADD COMPATIBILITY OPTIONS TO BE COMPATIBLE WITH JAVA 1.8
     // Added for Sentry support
@@ -21,8 +21,6 @@ android {
         targetSdkVersion 30
         versionCode 2
         versionName "1.1"
-
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
     }
 
@@ -41,17 +39,9 @@ android {
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.6.0'
-    implementation 'androidx.appcompat:appcompat:1.3.1'
-    testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
-
-    implementation 'com.jakewharton.timber:timber:5.0.1'
-
-    // https://github.com/getsentry/sentry-java/releases
-    // Required so that we can reference the Sentry class
-    implementation 'io.sentry:sentry-android:5.1.2'
-
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
+
+    implementation "com.jakewharton.timber:timber:$timber"
+    // https://github.com/getsentry/sentry-java/releases
+    implementation "io.sentry:sentry-android:$sentry"
 }

--- a/steamclog/build.gradle
+++ b/steamclog/build.gradle
@@ -1,9 +1,9 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'com.github.dcendents.android-maven'
-group='com.github.steamclock'
-// Note, do not apply sentry plugins here; must be done in application module
+plugins {
+    id 'com.android.library'
+    id 'kotlin-android'
+    id 'kotlin-android-extensions'
+    // Note, do not apply sentry plugins here; must be done in application module
+}
 
 android {
     compileSdkVersion 30
@@ -41,17 +41,17 @@ android {
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.3.2'
-    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.core:core-ktx:1.6.0'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 
-    implementation 'com.jakewharton.timber:timber:4.7.1'
+    implementation 'com.jakewharton.timber:timber:5.0.1'
 
     // https://github.com/getsentry/sentry-java/releases
     // Required so that we can reference the Sentry class
-    implementation 'io.sentry:sentry-android:5.1.0'
+    implementation 'io.sentry:sentry-android:5.1.2'
 
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 }

--- a/steamclog/src/main/java/com/steamclock/steamclog/Destinations.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/Destinations.kt
@@ -276,7 +276,14 @@ internal fun Timber.Tree.isLoggable(treeLevel: LogLevel, logPriority: Int): Bool
  * This is based on how Timber generates the stacktrace location for itself normally.
  */
 private fun createCustomStackElementTag(): String {
-    val SC_CALL_STACK_INDEX = 9 // Need to go back X in the call stack to get to the actual calling method.
+    /**
+     * How many items we need to "go back" in the call stack to get to method that called our
+     * steamclog logging method.
+     *
+     * NOTE: This number may change when libraries are updated, as those updates may affect the
+     * state of the stack trace and how the stack is handled.
+     */
+    val SC_CALL_STACK_INDEX = 8
 
     // ---- Taken directly from Timber ----
     // DO NOT switch this to Thread.getCurrentThread().getStackTrace(). The test will pass
@@ -292,6 +299,12 @@ private fun createCustomStackElementTag(): String {
 
     // Since unit testing is hard to do currently, add one more test on Debug builds that
     // attempts to determine if the stack index is pointing to the correct location.
+    //
+    // NOTE: If these checks are failing then it's possible a library has been updated which may
+    // have affected the depth of the call stack at this point, and as such the SC_CALL_STACK_INDEX
+    // may need to be updated. Place a debug break here, check the stackTrace array and find which
+    // index the actual logging call was made. This will most likely be the new
+    // SC_CALL_STACK_INDEX value.
     if (SteamcLog.config.isDebug && !internalLog) {
         check(beforeCutoff.fileName == steamclogFileName)
             { "createCustomStackElementTag failed: Element before cutoff no longer correct" }


### PR DESCRIPTION
### Related Issue: #86


### Summary of Problem:
* When updating Sentry, I noticed that the documentation was using syntax for a version of gradle that Steamclog did not support
* This was causing odd build failures after we attempted to update Sentry (#78)
* Even though we could fix this by using the old gradle syntax for importing plugins (#85), it would be better if we updated gradle and fixed these breaking changes.

### Proposed Solution:
* Update gradle from 4.1 to 7.0
* Fixed gradle plugin syntax
* Removed a bunch of unused libraries (@JeremyChiang  you were correct, it looks like we do not have to import the Sentry library again!)
* Moved steamclog 3rd party library versions to be ext variables
* Updated all 3rd party libraries - including Timber (note: internal changes in Timber caused a change in the call stack such that I need to update SC_CALL_STACK_INDEX - see full details below).

### Testing Steps:
1. Run sample app
2. Set Log Level to RELEASE
3. Send a non fatal report
4. Check Sentry for the sample app https://sentry.io/organizations/steamclock-software/issues/?project=5399932 
5. Make sure that the new issues logged (should be 4) all have readable call stacks
![image](https://user-images.githubusercontent.com/5217641/132901008-a9adf8b3-2caf-4daf-9fc6-dc2c2e861aa6.png)

### Details on SC_CALL_STACK_INDEX change:

**Old stack trace (using Timber 4.7.1)**
![Screen Shot 2021-09-10 at 10 33 38 AM](https://user-images.githubusercontent.com/5217641/132900579-98a95ad9-ab9c-4f68-902d-531af9a40bb7.png)

**New Stack trace (using Timber 5.0.1)**
![Screen Shot 2021-09-10 at 10 38 50 AM](https://user-images.githubusercontent.com/5217641/132900550-852176b9-25a3-4e09-9dc0-4e930f286061.png)

See that the new stack trace contains 1 less entry in the stack for performing the logging functionality (ie the `timber.log.Timber` calls), and as such, I needed to knock `SC_CALL_STACK_INDEX` down one in our library to match. 