### PR TITLE
Update to match specs from TechWG discussion (#83)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on the Steamclock [Release Management Guide](https://github.
 ## Unreleased 
 - Added ThrowableBlocker functional interface to allow specific Throwables/Exceptions to be suppressed from being sent as an error to the crash reporting destination (#22)
 - Update Sentry from 4.3.0 to 5.1.0
-- [1] Add log rotation functionality 
+- [1] Add log rotation functionality
+- Update Log Level Presets to match specs from TechWG discussion (#83)
 
 ---
 

--- a/app/src/main/java/com/steamclock/steamclogsample/MainActivity.kt
+++ b/app/src/main/java/com/steamclock/steamclogsample/MainActivity.kt
@@ -41,8 +41,8 @@ class MainActivity : AppCompatActivity() {
         }
 
         level_selector.setSelection(when (clog.config.logLevel) {
-            LogLevelPreset.Firehose -> 0
-            LogLevelPreset.Develop -> 1
+            LogLevelPreset.DebugVerbose -> 0
+            LogLevelPreset.Debug -> 1
             LogLevelPreset.Release -> 2
             LogLevelPreset.ReleaseAdvanced -> 3
             else -> 0
@@ -59,10 +59,10 @@ class MainActivity : AppCompatActivity() {
             ) {
                 clog.config.logLevel = when (position) {
                     0 -> {
-                        LogLevelPreset.Firehose
+                        LogLevelPreset.DebugVerbose
                     }
                     1 -> {
-                        LogLevelPreset.Develop
+                        LogLevelPreset.Debug
                     }
                     2 -> {
                         LogLevelPreset.Release
@@ -71,7 +71,7 @@ class MainActivity : AppCompatActivity() {
                         LogLevelPreset.ReleaseAdvanced
                     }
                     else -> {
-                        LogLevelPreset.Firehose
+                        LogLevelPreset.DebugVerbose
                     }
                 }
                 demo_text.text = clog.toString()
@@ -80,7 +80,7 @@ class MainActivity : AppCompatActivity() {
         }
     }
     private fun showMessageIfCrashReportingNotEnabled() {
-        if (clog.config.logLevel.sentry == LogLevel.None) {
+        if (clog.config.logLevel.remote == LogLevel.None) {
             Toast.makeText(applicationContext,
                 "Set Log Level to Release or Release Advanced to enable crash reporting",
                 Toast.LENGTH_LONG).show()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,9 +3,9 @@
     <string name="title_activity_main">MainActivity</string>
 
     <string-array name="levels">
-        <item>FIREHOSE</item>
-        <item>DEVELOP</item>
-        <item>RELEASE</item>
+        <item>DebugVerbose</item>
+        <item>Debug</item>
+        <item>Release</item>
         <item>ReleaseAdvanced</item>
     </string-array>
 </resources>

--- a/steamclog/src/main/java/com/steamclock/steamclog/Config.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/Config.kt
@@ -24,7 +24,7 @@ data class Config(
     /**
      * Destination logging levels
      */
-    var logLevel: LogLevelPreset = if (isDebug) LogLevelPreset.Firehose else LogLevelPreset.Release,
+    var logLevel: LogLevelPreset = if (isDebug) LogLevelPreset.Debug else LogLevelPreset.Release,
 
     /**
      *  Determines how long generated log files are kept for.

--- a/steamclog/src/main/java/com/steamclock/steamclog/Destinations.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/Destinations.kt
@@ -21,7 +21,7 @@ import java.util.*
 // they are to consume the logged item or not.
 //-----------------------------------------------------------------------------
 /**
- * SentryDestination
+ * SentryDestination == remote
  */
 internal class SentryDestination : Timber.Tree() {
 
@@ -30,7 +30,7 @@ internal class SentryDestination : Timber.Tree() {
     }
 
     override fun isLoggable(priority: Int): Boolean {
-        return isLoggable(SteamcLog.config.logLevel.sentry, priority)
+        return isLoggable(SteamcLog.config.logLevel.remote, priority)
     }
 
     /**
@@ -99,7 +99,7 @@ internal class ConsoleDestination: Timber.DebugTree() {
 }
 
 /**
- * ExternalLogFileDestination
+ * ExternalLogFileDestination == Disk
  * DebugTree gives us access to override createStackElementTag
  */
 internal class ExternalLogFileDestination : Timber.DebugTree() {
@@ -112,7 +112,7 @@ internal class ExternalLogFileDestination : Timber.DebugTree() {
     private var currentLogFileCachedTime: Long? = null
 
     override fun isLoggable(priority: Int): Boolean {
-        return isLoggable(SteamcLog.config.logLevel.file, priority)
+        return isLoggable(SteamcLog.config.logLevel.disk, priority)
     }
 
     //---------------------------------------------

--- a/steamclog/src/main/java/com/steamclock/steamclog/LogLevelPreset.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/LogLevelPreset.kt
@@ -7,61 +7,44 @@ package com.steamclock.steamclog
  */
 sealed class LogLevelPreset {
 
-    /// Disk: verbose, system: verbose, remote: none
-    object Firehose: LogLevelPreset()
-
-    /// Disk: none, system: debug, remote: none
-    object Develop: LogLevelPreset()
-
-    /// Disk: verbose, system: none, remote: warn
+    object DebugVerbose: LogLevelPreset()
+    object Debug: LogLevelPreset()
     object ReleaseAdvanced: LogLevelPreset()
-
-    /// Disk: none, system: none, remote: warn
     object Release: LogLevelPreset()
 
     val title: String
         get() = when(this) {
-            is Firehose -> "Firehose"
-            is Develop -> "Develop"
-            is ReleaseAdvanced -> "ReleaseAdvanced"
+            is DebugVerbose -> "DebugVerbose"
+            is Debug -> "Debug"
             is Release -> "Release"
-        }
-
-    val global: LogLevel
-        get() = when(this) {
-            is Firehose -> LogLevel.Info
-            is Develop -> LogLevel.Info
-            is ReleaseAdvanced -> LogLevel.Info
-            is Release -> LogLevel.Info
-        }
-
-    val sentry: LogLevel
-        get() = when(this) {
-            is Firehose -> LogLevel.None
-            is Develop -> LogLevel.None
-            is ReleaseAdvanced -> LogLevel.Verbose
-            is Release -> LogLevel.Info
-        }
-
-    val file: LogLevel
-        get() = when(this) {
-            is Firehose -> LogLevel.Verbose
-            is Develop -> LogLevel.None
-            is ReleaseAdvanced -> LogLevel.Verbose
-            is Release -> LogLevel.None
+            is ReleaseAdvanced -> "ReleaseAdvanced"
         }
 
     val console: LogLevel
         get() = when(this) {
-            is Firehose -> LogLevel.Verbose
-            is Develop -> LogLevel.Debug
-            is ReleaseAdvanced -> LogLevel.None
+            is DebugVerbose -> LogLevel.Verbose
+            is Debug -> LogLevel.Debug
             is Release -> LogLevel.None
+            is ReleaseAdvanced -> LogLevel.None
         }
 
-    val analyticsEnabled = false
+    val disk: LogLevel
+        get() = when(this) {
+            is DebugVerbose -> LogLevel.Verbose
+            is Debug -> LogLevel.Debug
+            is Release -> LogLevel.Info
+            is ReleaseAdvanced -> LogLevel.Debug
+        }
+
+    val remote: LogLevel
+        get() = when(this) {
+            is DebugVerbose -> LogLevel.None
+            is Debug -> LogLevel.None
+            is Release -> LogLevel.Info
+            is ReleaseAdvanced -> LogLevel.Debug
+        }
 
     override fun toString(): String {
-        return "$title(global=$global, console=$console, file=$file, sentry=$sentry)"
+        return "$title(console=$console, disk=$disk, remote=$remote)"
     }
 }


### PR DESCRIPTION
### Related Issue: #83

### Summary of Problem:
In our TechWG meeting where we reviewed Steamclog usage, we decided on some updates to how LogLevelPresets were named and what their LogLevel mappings were: 
![image](https://user-images.githubusercontent.com/5217641/132917283-d059407f-e9bf-4fb4-a39d-181961c88459.png)

Tech WG Doc: 
https://coda.io/d/Tech-Working-Group_dq8QHMnEi6A/Aug-16th-2021_suivT#_luAHl

### Proposed Solution:
* Renamed LogLevelPresets
* Renamed LogLevelPreset destinations to match spec (ie. remote instead of sentry)
* Updated LogLevelPreset LogLevels
* Steamclog now defaults to LogLevelPreset `Debug` for debug builds (was previously Firehose)

### Testing Steps:
These should mostly be internal changes, but the sample app should now show the updated levels: 
![image](https://user-images.githubusercontent.com/5217641/132917220-45aeff32-b1f8-4ce6-a232-af847f0fd7d0.png)