### PR TITLE
initWith now takes Config parameter; made file path non-optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on the Steamclock [Release Management Guide](https://github.
 - [1] Add log rotation functionality
 - Update Log Level Presets to match specs from TechWG discussion (#83)
 - Updated to Gradle 7.0; updated 3rd party libraries (#86)
+- InitWith method takes Config parameter (#91)
 
 ---
 

--- a/app/src/main/java/com/steamclock/steamclogsample/App.kt
+++ b/app/src/main/java/com/steamclock/steamclogsample/App.kt
@@ -1,6 +1,7 @@
 package com.steamclock.steamclogsample
 
 import android.app.Application
+import com.steamclock.steamclog.Config
 import com.steamclock.steamclog.ThrowableBlocker
 import com.steamclock.steamclog.clog
 
@@ -11,7 +12,7 @@ import com.steamclock.steamclog.clog
 class App: Application() {
     override fun onCreate() {
         super.onCreate()
-        clog.initWith(BuildConfig.DEBUG, externalCacheDir)
+        clog.initWith(Config(BuildConfig.DEBUG, externalCacheDir))
         clog.throwableBlocker = ThrowableBlocker { throwable ->
             when (throwable) {
                 is BlockedException1 -> {

--- a/steamclog/src/main/java/com/steamclock/steamclog/Config.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/Config.kt
@@ -9,37 +9,38 @@ import java.io.File
  */
 data class Config(
     /**
-     * BuildConfig is tied to the module (ie. the Steamclog library module), so we cannot use it to determine
+     * Required; BuildConfig is tied to the module (ie. the Steamclog library module), so we cannot use it to determine
      * a default logLevel as this will always be set to false when the library is being imported via JitPack.
      * As such this info must be given to us by the application.
      */
-    val isDebug: Boolean = false,
+     val isDebug: Boolean,
 
     /**
-     * Location where the app wishes to store any log files generated (ex. externalCacheDir)
+     * Required; Location where the app wishes to store any log files generated (ex. externalCacheDir)
      * Required on creation and will not change.
      */
-    val fileWritePath: File? = null,
+    val fileWritePath: File?,
 
     /**
-     * Destination logging levels
-     */
-    var logLevel: LogLevelPreset = if (isDebug) LogLevelPreset.Debug else LogLevelPreset.Release,
-
-    /**
-     *  Determines how long generated log files are kept for.
+     *  Optional; Determines how long generated log files are kept for.
      */
     var keepLogsForDays: Int = 3,
 
     /**
-     *  Configuration for auto-rotating file behaviour
+     *  Optional; Configuration for auto-rotating file behaviour
      */
     var autoRotateConfig: AutoRotateConfig = AutoRotateConfig(),
 
     /**
-     * Indicates if objects being logged must implement the redacted interface.
+     * Optional; Indicates if objects being logged must implement the redacted interface.
      */
-    var requireRedacted: Boolean = false
+    var requireRedacted: Boolean = false,
+
+    /**
+     * Optional; Destination logging levels. In most cases we should use the default values, but
+     * could be changed at runtime to allow for more detailed reporting.
+     */
+    var logLevel: LogLevelPreset = if (isDebug) LogLevelPreset.Debug else LogLevelPreset.Release
 
 ) {
     override fun toString(): String {

--- a/steamclog/src/main/java/com/steamclock/steamclog/Steamclog.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/Steamclog.kt
@@ -6,7 +6,6 @@ import io.sentry.Sentry
 import io.sentry.protocol.User
 import org.jetbrains.annotations.NonNls
 import timber.log.Timber
-import java.io.File
 
 /**
  * Steamclog
@@ -31,7 +30,7 @@ object SteamcLog {
     //---------------------------------------------
     // Public properties
     //---------------------------------------------
-    var config: Config = Config()
+    lateinit var config: Config
         private set
 
     /**
@@ -54,14 +53,13 @@ object SteamcLog {
         // Don't plant yet; fileWritePath required before we can start writing to ExternalLogFileDestination
     }
 
-    fun initWith(isDebug: Boolean,
-                 fileWritePath: File? = null,
-                 fileRotationSeconds: Long = AutoRotateConfig.defaultFileRotationSeconds) {
-        fileWritePath?.let {
-            this.config = Config(isDebug, fileWritePath, autoRotateConfig = AutoRotateConfig(fileRotationSeconds))
+    fun initWith(config: Config) {
+        this.config = config
+        this.config.fileWritePath?.let {
             updateTree(externalLogFileTree, true)
+        } ?: run {
+            logInternal(LogLevel.Warn, "fileWritePath given was null; cannot log to external file")
         }
-
         logInternal(LogLevel.Info, "Steamclog initialized:\n$this")
     }
 


### PR DESCRIPTION
### Related Issue: #91 


### Summary of Problem:
* Trying to simplify the setup process
* iOS currently initialized using a Config object, but Android takes multiple parameters (ie. platform difference)
* file path on Android was optional, when it really shouldn't be (lead to a more complicated setup)

### Proposed Solution:
* Have `initWith` method take a config object
* Make file path required
* Added some comments about which config params are required vs. optional.

### Testing Steps:
1. Run sample app from Android Studio
2. Make sure logs are being sent to the console
3. Make sure when you press the Show File Dump button that theres data there.

### Note
Readme will be updated at the end of these changes, and will include the new init steps