### PR TITLE
Renamed ThrowableBlocker to FilterOut (#95)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on the Steamclock [Release Management Guide](https://github.
 - Update Log Level Presets to match specs from TechWG discussion (#83)
 - Updated to Gradle 7.0; updated 3rd party libraries (#86)
 - InitWith method takes Config parameter (#91)
+- Renamed ThrowableBlocker to FilterOut (#95)
 
 ---
 

--- a/app/src/main/java/com/steamclock/steamclogsample/App.kt
+++ b/app/src/main/java/com/steamclock/steamclogsample/App.kt
@@ -2,18 +2,25 @@ package com.steamclock.steamclogsample
 
 import android.app.Application
 import com.steamclock.steamclog.Config
-import com.steamclock.steamclog.ThrowableBlocker
+import com.steamclock.steamclog.FilterOut
 import com.steamclock.steamclog.clog
 
 /**
  * steamclog
  * Created by jake on 2020-03-27, 2:40 PM
  */
-class App: Application() {
+class App : Application() {
     override fun onCreate() {
         super.onCreate()
-        clog.initWith(Config(BuildConfig.DEBUG, externalCacheDir))
-        clog.throwableBlocker = ThrowableBlocker { throwable ->
+        clog.initWith(Config(
+            isDebug = BuildConfig.DEBUG,
+            fileWritePath = externalCacheDir,
+            filtering = appFiltering
+        ))
+    }
+
+    companion object {
+        val appFiltering = FilterOut { throwable ->
             when (throwable) {
                 is BlockedException1 -> {
                     true
@@ -29,6 +36,6 @@ class App: Application() {
     }
 }
 
-class BlockedException1(message: String): Exception(message)
-class BlockedException2(message: String): Exception(message)
-class AllowedException(message: String): Exception(message)
+class BlockedException1(message: String) : Exception(message)
+class BlockedException2(message: String) : Exception(message)
+class AllowedException(message: String) : Exception(message)

--- a/steamclog/src/main/java/com/steamclock/steamclog/Config.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/Config.kt
@@ -37,6 +37,13 @@ data class Config(
     var requireRedacted: Boolean = false,
 
     /**
+     * Optional; If set the FilterOut interface will be called to determine if the Throwable
+     * being logged should be sent to the remote destination, or be filtered out.
+     * By default no Throwables will be filtered.
+     */
+    var filtering: FilterOut = FilterOut { false },
+
+    /**
      * Optional; Destination logging levels. In most cases we should use the default values, but
      * could be changed at runtime to allow for more detailed reporting.
      */

--- a/steamclog/src/main/java/com/steamclock/steamclog/Destinations.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/Destinations.kt
@@ -53,7 +53,7 @@ internal class SentryDestination : Timber.Tree() {
             priority == Log.ERROR && originalThrowable != null -> {
                 // Check to see if we want to allow or block the Throwable from being reported
                 // as an error.
-                if (SteamcLog.throwableBlocker.shouldBlock(originalThrowable)) {
+                if (SteamcLog.config.filtering.shouldBlock(originalThrowable)) {
                     Sentry.addBreadcrumb("${originalThrowable::class.simpleName} on blocked list, and has " +
                             "been blocked from being captured as an exception: " +
                             "${originalThrowable.message}", breadcrumbCategory)

--- a/steamclog/src/main/java/com/steamclock/steamclog/FilterOut.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/FilterOut.kt
@@ -6,6 +6,6 @@ package com.steamclock.steamclog
  * Throwable should be blocked from being logged as an error by the crash reporting
  * destination.
  */
-fun interface ThrowableBlocker {
+fun interface FilterOut {
     fun shouldBlock(throwable: Throwable): Boolean
 }

--- a/steamclog/src/main/java/com/steamclock/steamclog/Steamclog.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/Steamclog.kt
@@ -33,12 +33,6 @@ object SteamcLog {
     lateinit var config: Config
         private set
 
-    /**
-     * Can be overridden by the application to allow Throwables to be filtered out before
-     * being sent as errors to the crash reporting destination.
-     */
-    var throwableBlocker: ThrowableBlocker = ThrowableBlocker { false } // By default filter nothing
-
     init {
         // By default plant all trees; setting their level to LogLevel.None will effectively
         // disable that tree, but we do not uproot it.


### PR DESCRIPTION
### Related Issue: #95


### Summary of Problem:
Original name for interface was very Android specific; we'd like our API to be mostly cross platform, so we wanted to rename it accordingly,.

### Proposed Solution:
* Renamed to match spec ("filtering" / "FilteredOut")
* Moved property to config class to match spec

### Testing Steps:
1. Run sample app
2. Set log level to Release
3. Hit the "Log Blocked Exception" button
4. Check Sentry and make sure only the `AllowedException` was logged 
![image](https://user-images.githubusercontent.com/5217641/133317621-8446b958-8d9c-4a1c-b97a-699e3df31c52.png)

Readme will be updated in #88 