### PR TITLE
Added jitpack.yml file to indicate that our gradle plugin requires JDK 11

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,3 @@
+# configuration file for building snapshots and releases with jitpack.io
+jdk:
+  - openjdk11


### PR DESCRIPTION
### Summary of Problem:
* Last release to Jitpack failed due to incompatible JDK versions 

### Proposed Solution:
* As per jitpack documentation, added `jitpack.yml` file which indicates the required JDK version

### Testing Steps:
* Cannot test until I push this to Jitpack and see if the release builds