### PR TITLE
Failed Jitpack Build (#99)

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,3 @@
+# configuration file for building snapshots and releases with jitpack.io
+jdk:
+  - openjdk11

--- a/steamclog/build.gradle
+++ b/steamclog/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'kotlin-android-extensions'
+    id 'maven-publish'
     // Note, do not apply sentry plugins here; must be done in application module
 }
 


### PR DESCRIPTION
### Related Issue: #99


### Summary of Problem:
Found in Jitpack build log:
```
* Where:
Script '/script/maven-plugin.gradle' line: 2

* What went wrong:
A problem occurred evaluating script.
> Failed to apply plugin 'com.github.dcendents.android-maven'.
   > Could not create plugin of type 'AndroidMavenPlugin'.
      > Could not generate a decorated class for type AndroidMavenPlugin.
         > org/gradle/api/publication/maven/internal/MavenPomMetaInfoProvider
```

### Proposed Solution:
Looks like we may need to explicitly set the maven plugin 
https://docs.gradle.org/current/userguide/publishing_maven.html