### PR TITLE
[#106] Sentry reports use message instead of exception names for titles 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on the Steamclock [Release Management Guide](https://github.
 
 - Updated libraries including Sentry (#101)
 - Replaced kotlin synthetics with ViewBinding in sample app (#47) 
+- Update kotlin version, and dependencies again (part of #106)
 
 ---
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,9 +49,8 @@ dependencies {
     implementation project(':steamclog')
     // Since Sentry is a dependency of steamclog, we do not have to import it again
 
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.2'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.2'
     implementation 'androidx.appcompat:appcompat:1.4.1'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
-    implementation 'com.google.android.material:material:1.5.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'com.google.android.material:material:1.6.1'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = '1.5.30'
+    ext.kotlin_version = '1.7.10'
     ext.timber = '5.0.1'
-    ext.sentry = '5.7.1'
+    ext.sentry = '6.4.0'
 
     repositories {
         google()

--- a/steamclog/build.gradle
+++ b/steamclog/build.gradle
@@ -57,7 +57,8 @@ android {
 
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    // https://blog.jetbrains.com/kotlin/2020/07/kotlin-1-4-rc-released/
+    // No longer need to include kotlin stdlib dependency
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 
     implementation "com.jakewharton.timber:timber:$timber"


### PR DESCRIPTION
### Related Issue: #106 


### Summary of Problem:
If exceptions are passed to the error function, the exception name is currently being used as the Sentry issue title. In most cases this is not useful, as we care more about the "situation" that caused the error (ie. the message) than the actual exception name which may often be fairly generic and nondescript.

### Proposed Solution:
* Log the exception stack trace as a breadcrumb
* Use the message given as the error report title; this will force more contextual information to be given about a crash report

While doing this I also:
* Updated dependencies
* Improved Sentry breadcrumbs to better match the priority level (allows us to filter better on Sentry)

### Testing Steps:
1. Run the sample app
2. Change log level to `ReleaseAdvanced`
3. Click the `Log Things` button
4. Click the `Send non-fatal` button
5. Go to the Sentry page for the sample app: https://sentry.io/organizations/steamclock-software/issues/?project=5399932&referrer=github_integration
6. Make sure the following 4 errors have been reported recently. These error reports use the message given in the sample app (not the Throwable name itself!)
![image](https://user-images.githubusercontent.com/5217641/187544449-2c865c78-97e7-401c-97d3-555d139e5ecf.png)
7. On the Error with Throwable reports, click through and make sure the most recent report has the stack trace in the breadcrumbs:
![image](https://user-images.githubusercontent.com/5217641/187544727-2b279283-10d8-4317-b987-7f7d53950086.png)
8. Also make sure that the breadcrumbs contain both error and info entries (see above).