### PR TITLE
Updated to SDK 33, kotlin and Sentry dependencies (#108)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on the Steamclock [Release Management Guide](https://github.com/steamclock/labs/wiki/Release-Management-Guide).
 
-## Unreleased 
+## v2.2 Unreleased
+- Updated to SDK 33, kotlin and Sentry dependencies (#108)
+
+---
+
+## Jitpack v2.1 : Aug 30, 2022
 
 - Updated libraries including Sentry (#101)
 - Replaced kotlin synthetics with ViewBinding in sample app (#47) 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,7 @@ plugins {
 }
 
 android {
-    compileSdkVersion 31    // Android 12 (2021)
-    buildToolsVersion "31.0.0"
+    compileSdkVersion versions.compileSdk
 
     kotlinOptions {
         jvmTarget = "1.8"
@@ -26,7 +25,7 @@ android {
     defaultConfig {
         applicationId "com.steamclock.steamclogsample"
         minSdkVersion 21
-        targetSdkVersion 31 // Android 12 (2021)
+        targetSdkVersion versions.compileSdk
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -48,7 +47,6 @@ android {
 dependencies {
     implementation project(':steamclog')
     // Since Sentry is a dependency of steamclog, we do not have to import it again
-
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.2'
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = '1.7.10'
+    ext.kotlin_version = '1.8.0'
     ext.timber = '5.0.1'
-    ext.sentry = '6.4.0'
+    ext.sentry = '6.17.0'
 
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@
 buildscript {
 
     ext.versions = [
-        "minSdk": 24,
         "compileSdk": 33,
         "kotlin": "1.8.10",
         "timber": "5.0.1",

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = '1.8.0'
-    ext.timber = '5.0.1'
-    ext.sentry = '6.17.0'
+
+    ext.versions = [
+        "minSdk": 24,
+        "compileSdk": 33,
+        "kotlin": "1.8.10",
+        "timber": "5.0.1",
+        "sentry": "6.17.0"
+    ]
 
     repositories {
         google()
@@ -11,7 +16,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:7.0.4'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/steamclog/build.gradle
+++ b/steamclog/build.gradle
@@ -18,7 +18,7 @@ afterEvaluate {
                 // You can then customize attributes of the publication as shown below.
                 groupId = 'com.steamclock.steamclog'
                 artifactId = 'release'
-                version = 'v2.1'
+                version = 'v2.2'
             }
         }
     }
@@ -58,9 +58,9 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     // https://blog.jetbrains.com/kotlin/2020/07/kotlin-1-4-rc-released/
     // No longer need to include kotlin stdlib dependency
-    implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-reflect:${versions.kotlin}"
 
-    implementation "com.jakewharton.timber:timber:$timber"
+    implementation "com.jakewharton.timber:timber:${versions.timber}"
     // https://github.com/getsentry/sentry-java/releases
-    implementation "io.sentry:sentry-android:$sentry"
+    implementation "io.sentry:sentry-android:${versions.sentry}"
 }

--- a/steamclog/build.gradle
+++ b/steamclog/build.gradle
@@ -25,8 +25,7 @@ afterEvaluate {
 }
 
 android {
-    compileSdkVersion 31    // Android 12 (2021)
-    buildToolsVersion "31.0.0"
+    compileSdkVersion 33
 
     // ADD COMPATIBILITY OPTIONS TO BE COMPATIBLE WITH JAVA 1.8
     // Added for Sentry support
@@ -37,9 +36,9 @@ android {
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 31 // Android 12 (2021)
-        versionCode 2
-        versionName "1.1"
+        targetSdkVersion 33
+        versionCode 3
+        versionName "2.2"
         consumerProguardFiles "consumer-rules.pro"
     }
 

--- a/steamclog/build.gradle
+++ b/steamclog/build.gradle
@@ -25,7 +25,7 @@ afterEvaluate {
 }
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion versions.compileSdk
 
     // ADD COMPATIBILITY OPTIONS TO BE COMPATIBLE WITH JAVA 1.8
     // Added for Sentry support
@@ -36,7 +36,7 @@ android {
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 33
+        targetSdkVersion versions.compileSdk
         versionCode 3
         versionName "2.2"
         consumerProguardFiles "consumer-rules.pro"


### PR DESCRIPTION
**Note, cannot properly test until Sentry rate limits are lifted**
I'd like to get this PR in ASAP though so we can continue with the other app updates, so if you're ok with it I'd like to get this PR accepted and then run the final tests after April 22nd when the Sentry limit is lifted.

### Related Issue: #108 


### Summary of Problem:
* It's been awhile since dependencies have been updated
* Need to support target SDK 33 by August

### Proposed Solution:
* Updated target SDK to 33
* Updated Kotlin to 1.8.10 (newest at time)
* Updated to Sentry 6.17.0 (newest at time)

### Testing Steps:
* Build app, make sure app builds (dev task)
* Run sample app, set log level to ReleaseAdvanced, Send analytic and Non fatals
* Check Sentry to make sure events were correctly created: https://steamclock-software.sentry.io/issues/?project=5399932
(Note right now we are at our Sentry rate limit so I cannot test this)