### PR TITLE
[#111] Added info to avoid Sentry duplications (due to 3rd party Timber integration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,14 @@ If the application is **not** setup to report to Sentry yet, do the following:
     ```
     'io.sentry.android.gradle' 
     ```
+   And to avoid Sentry from using the default Timber intergration, add the following also in the app's `build.gradle` file:
+    ```
+    configurations.configureEach {
+      exclude group: "io.sentry", module: "sentry-android-timber"
+    }
+    ```
+   (See https://docs.sentry.io/platforms/android/configuration/integrations/timber/ for full details)
+   
 
 #### Filtering out some Throwables from being logged to Sentry
 See the `FilterOut` interface and `filtering` config property.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,17 @@ plugins {
     id 'com.android.application'
     id 'kotlin-android'
     // Provides auto-uploading of proguard mappings to Sentry
-    id 'io.sentry.android.gradle' version '2.1.4'
+    id 'io.sentry.android.gradle' version '3.5.0'
+}
+
+/**
+ * Sentry has it's own Timber integration, which is automatically added with the
+ * "io.sentry.android.gradle" plugin; we do NOT want to enable this as it will result in
+ * errors being reported twice (with different messages)
+ * https://docs.sentry.io/platforms/android/configuration/integrations/timber/
+ */
+configurations.configureEach {
+    exclude group: "io.sentry", module: "sentry-android-timber"
 }
 
 android {

--- a/app/src/main/java/com/steamclock/steamclogsample/MainActivity.kt
+++ b/app/src/main/java/com/steamclock/steamclogsample/MainActivity.kt
@@ -32,7 +32,8 @@ class MainActivity : AppCompatActivity() {
         binding.demoText.text = clog.toString()
         binding.logThings.setOnClickListener { testLogging() }
         binding.dumpFileButton.setOnClickListener { testLogDump() }
-        binding.nonFatal.setOnClickListener { testNonFatal() }
+        binding.allNonFatals.setOnClickListener { testAllNonFatals() }
+        binding.singleNonFatal.setOnClickListener{ testSingleNonFatal() }
         binding.logBlockedException.setOnClickListener { testBlockedException() }
         binding.trackAnalytic.setOnClickListener {
             Toast.makeText(applicationContext, "Not supported", Toast.LENGTH_LONG).show()
@@ -141,9 +142,15 @@ class MainActivity : AppCompatActivity() {
             Toast.LENGTH_LONG).show()
     }
 
-    private fun testNonFatal() {
+    private fun testSingleNonFatal() {
         showMessageIfCrashReportingNotEnabled()
-        clog.info("Running testNonFatal")
+        clog.info("Running testSingleNonFatal")
+        testNonFatalMessageOnly()
+    }
+
+    private fun testAllNonFatals() {
+        showMessageIfCrashReportingNotEnabled()
+        clog.info("Running testAllNonFatals")
 
         // NOTE, Sentry seems to apply some grouping logic such that the *same* Throwable thrown
         // in the *same* function will be grouped no matter what messages they are given, such

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -56,12 +56,83 @@
 
             <Button
                 style="@style/Widget.AppCompat.Button.Colored"
+                android:id="@+id/add_user_id"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="wrap_content"
+                android:text="Set UserId (1234)"
+                android:layout_gravity="center"/>
+
+            <Button
+                style="@style/Widget.AppCompat.Button.Colored"
                 android:id="@+id/log_things"
                 android:layout_width="0dp"
                 android:layout_weight="1"
                 android:layout_height="wrap_content"
-                android:text="LOG THINGS"
+                android:text="Add logs"
                 android:layout_gravity="center"/>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <Button
+                style="@style/Widget.AppCompat.Button.Colored"
+                android:id="@+id/single_non_fatal"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="wrap_content"
+                android:text="Report Single Error"
+                android:backgroundTint="@android:color/holo_red_dark"
+                android:layout_gravity="center"/>
+
+            <Button
+                style="@style/Widget.AppCompat.Button.Colored"
+                android:id="@+id/all_non_fatals"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="wrap_content"
+                android:text="Report Multiple Errors"
+                android:backgroundTint="@android:color/holo_red_dark"
+                android:layout_gravity="center"/>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <Button
+                style="@style/Widget.AppCompat.Button.Colored"
+                android:id="@+id/log_blocked_exception"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="wrap_content"
+                android:text="Report Blocked Exception"
+                android:backgroundTint="@android:color/holo_red_dark"
+                android:layout_gravity="center"/>
+
+            <Button
+                style="@style/Widget.AppCompat.Button.Colored"
+                android:id="@+id/track_analytic"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="wrap_content"
+                android:text="Report Analytic Event"
+                android:backgroundTint="@android:color/holo_red_dark"
+                android:layout_gravity="center"/>
+
+        </LinearLayout>
+
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
 
             <Button
                 style="@style/Widget.AppCompat.Button.Colored"
@@ -72,55 +143,10 @@
                 android:text="SHOW FILE DUMP"
                 android:layout_gravity="center"/>
 
-        </LinearLayout>
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <Button
-                style="@style/Widget.AppCompat.Button.Colored"
-                android:id="@+id/non_fatal"
+            <View
                 android:layout_width="0dp"
                 android:layout_weight="1"
-                android:layout_height="wrap_content"
-                android:text="Send Non Fatal"
-                android:layout_gravity="center"/>
-
-            <Button
-                style="@style/Widget.AppCompat.Button.Colored"
-                android:id="@+id/track_analytic"
-                android:layout_width="0dp"
-                android:layout_weight="1"
-                android:layout_height="wrap_content"
-                android:text="Send Analytic Event"
-                android:layout_gravity="center"/>
-
-        </LinearLayout>
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <Button
-                style="@style/Widget.AppCompat.Button.Colored"
-                android:id="@+id/add_user_id"
-                android:layout_width="0dp"
-                android:layout_weight="1"
-                android:layout_height="wrap_content"
-                android:text="Set UserId (1234)"
-                android:layout_gravity="center"/>
-
-            <Button
-                style="@style/Widget.AppCompat.Button.Colored"
-                android:id="@+id/log_blocked_exception"
-                android:layout_width="0dp"
-                android:layout_weight="1"
-                android:layout_height="wrap_content"
-                android:text="Log Blocked Exception"
-                android:layout_gravity="center"/>
+                android:layout_height="0dp" />
 
         </LinearLayout>
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         "compileSdk": 33,
         "kotlin": "1.8.10",
         "timber": "5.0.1",
-        "sentry": "6.17.0"
+        "sentry": "6.23.0"
     ]
 
     repositories {


### PR DESCRIPTION
### Related Issue: #111


### Summary of Problem:
https://docs.sentry.io/platforms/android/configuration/integrations/timber/
> Starting from version 3.1.0, the Sentry Android Gradle plugin will automatically add the sentry-android-timber dependency. The plugin will only add the sentry-android-timber dependency if a timber dependency was discovered on the classpath.

This will cause our errors to be duplicated in Sentry. 

### Proposed Solution:
* Unfortunately the actual fix will have to be done in each of our client app's gradle files, however, this PR documents the required changes in the PR and shows how to do it in the sample app
* I have also updated the sample app a little to make it easier to test out sending only a single error (which makes testing duplication much easier)

### Testing Steps:
1. Go to the Sentry page for the sample app: https://steamclock-software.sentry.io/issues/?project=5399932 
2. Select all of the issues in the list and select the "Resolve" button; this should clear the list of errors and make it easy to see new ones coming in.
3. Run the sample app, and change the log level at the top to `Release`
4. Press the "Report Single Error" button
5. Wait ~10seconds (sometimes it may take longer to send the report to Sentry)
6. Refresh the Sentry page 
7. Make sure you only see 1 error reported in Senty:
![image](https://github.com/steamclock/steamclog-android/assets/5217641/08d7df49-d54d-4b6f-af94-0acd1a3d250b)