### PR TITLE
[#114] Config.extraInfo now optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on the Steamclock [Release Management Guide](https://github.com/steamclock/labs/wiki/Release-Management-Guide).
 
+## Unlreleased
+- Config.extraInfo now optional (#114)
+
+
 ## Jitpack v2.3 : Jun 19, 2023
 - Added UserReports (#110)
 - Updated Sentry plugin version; added exclusion for "default" Timber/Sentry integration (#111)

--- a/app/src/main/java/com/steamclock/steamclogsample/App.kt
+++ b/app/src/main/java/com/steamclock/steamclogsample/App.kt
@@ -17,20 +17,7 @@ class App : Application() {
             isDebug = BuildConfig.DEBUG,
             fileWritePath = externalCacheDir,
             filtering = appFiltering,
-            detailedLogsOnUserReports = true,
-            extraInfo = { purpose ->
-                when (purpose) {
-                    ExtraInfoPurpose.Error -> {
-                        mapOf("ExtraInfoPurpose" to "Error")
-                    }
-                    ExtraInfoPurpose.Fatal -> {
-                        mapOf("ExtraInfoPurpose" to "Fatal")
-                    }
-                    ExtraInfoPurpose.UserReport -> {
-                        mapOf("ExtraInfoPurpose" to "UserReport")
-                    }
-                }
-            }
+            detailedLogsOnUserReports = true
         ))
     }
 

--- a/app/src/main/java/com/steamclock/steamclogsample/MainActivity.kt
+++ b/app/src/main/java/com/steamclock/steamclogsample/MainActivity.kt
@@ -19,6 +19,20 @@ class MainActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityMainBinding
 
+    private fun getExtraInfo(purpose: ExtraInfoPurpose): Map<String, Any> {
+        return when (purpose) {
+            ExtraInfoPurpose.Error -> {
+                mapOf("ExtraInfoPurpose" to "Error")
+            }
+            ExtraInfoPurpose.Fatal -> {
+                mapOf("ExtraInfoPurpose" to "Fatal")
+            }
+            ExtraInfoPurpose.UserReport -> {
+                mapOf("ExtraInfoPurpose" to "UserReport")
+            }
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityMainBinding.inflate(layoutInflater)
@@ -43,6 +57,9 @@ class MainActivity : AppCompatActivity() {
         }
         binding.enableUserReportLogs.setOnCheckedChangeListener { _, checked ->
             clog.config.detailedLogsOnUserReports = checked
+        }
+        binding.enableExtraConfigInfo.setOnCheckedChangeListener { _, checked ->
+            clog.config.extraInfo = if (checked) { this::getExtraInfo } else null
         }
 
         binding.addUserId.setOnClickListener { clog.setUserId("1234") }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -55,6 +55,12 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
 
+        <CheckBox
+            android:text="Add extra config info"
+            android:id="@+id/enable_extra_config_info"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
         <View
             android:layout_width="match_parent"
             android:layout_height="20dp" />

--- a/steamclog/src/main/java/com/steamclock/steamclog/Config.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/Config.kt
@@ -63,7 +63,7 @@ data class Config(
      * extra info passed into individual logging functions, this info is not redacted in any
      * way even if requireRedacted is set, the callback must handle and privacy preservation or redaction
      */
-    var extraInfo: (ExtraInfoPurpose) -> Map<String, Any>
+    var extraInfo: ((ExtraInfoPurpose) -> Map<String, Any>)? = null
 ) {
     override fun toString(): String {
         return "Config(" +

--- a/steamclog/src/main/java/com/steamclock/steamclog/Steamclog.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/Steamclog.kt
@@ -101,7 +101,7 @@ object SteamcLog {
         obj: Any?,
         purpose: ExtraInfoPurpose?
     ) {
-        val extraInfo = purpose?.let { config.extraInfo(purpose) }
+        val extraInfo = purpose?.let { config.extraInfo?.invoke(purpose) }
         val redactableObjectData =  obj?.getRedactedDescription()
         val logUrl = when (purpose == ExtraInfoPurpose.UserReport && config.detailedLogsOnUserReports) {
             true -> externalLogFileTree.getExternalFile()


### PR DESCRIPTION
### Related Issue: #114 


### Summary of Problem:
When I added the extra info config param I made it non optional, which isn't always desired. 

### Proposed Solution:
Made property optional

### Testing Steps:
To do this I have added a checkbox in the sample app that toggles between setting the property, and having it be set to null.

1. Go to sample app Sentry board https://steamclock-software.sentry.io/issues/?project=5399932 and delete all issues
2. Open sample app and set log level to Release (make sure "add extra config info" checkbox is NOT checked)
3. Press "Send User Report" button
4. Check "add extra config info"
5. Press "Send User Report" button again
6. Go to Sentry board (sometimes you have to wait a few seconds or refresh the board to get the issues to appear)
7. Make sure that there are two issues and that the "newest" issue contains the additional data section, but the oldest issue does not: 
![Screenshot 2023-08-01 at 12 13 48 PM](https://github.com/steamclock/steamclog-android/assets/5217641/108aecb6-3033-4fad-80fb-605935f264ad)