### PR TITLE
Removed unused "track" code (#64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on the Steamclock [Release Management Guide](https://github.
 ## Unreleased 
 - Allow more than one log to be attached to a Sentry report (#115)
 - Fixed issue with log auto rotation (#115)
-- Removed unused "track" code (#114)
+- Removed unused "track" code (#64)
 
 
 ## Jitpack v2.3 : Jun 19, 2023

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on the Steamclock [Release Management Guide](https://github.
 ## Unreleased 
 - Allow more than one log to be attached to a Sentry report (#115)
 - Fixed issue with log auto rotation (#115)
+- Removed unused "track" code (#114)
 
 
 ## Jitpack v2.3 : Jun 19, 2023

--- a/app/src/main/java/com/steamclock/steamclogsample/MainActivity.kt
+++ b/app/src/main/java/com/steamclock/steamclogsample/MainActivity.kt
@@ -40,9 +40,6 @@ class MainActivity : AppCompatActivity() {
         binding.singleNonFatal.setOnClickListener{ testSingleNonFatal() }
         binding.userReport.setOnClickListener { testUserReport() }
         binding.logBlockedException.setOnClickListener { testBlockedException() }
-        binding.trackAnalytic.setOnClickListener {
-            Toast.makeText(applicationContext, "Not supported", Toast.LENGTH_LONG).show()
-        }
         binding.enableUserReportLogs.setOnCheckedChangeListener { _, checked ->
             clog.config.detailedLogsOnUserReports = checked
         }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -91,6 +91,22 @@
 
             <Button
                 style="@style/Widget.AppCompat.Button.Colored"
+                android:id="@+id/dump_file_button"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="wrap_content"
+                android:text="SHOW FILE DUMP"
+                android:layout_gravity="center"/>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <Button
+                style="@style/Widget.AppCompat.Button.Colored"
                 android:id="@+id/single_non_fatal"
                 android:layout_width="0dp"
                 android:layout_weight="1"
@@ -118,34 +134,6 @@
 
             <Button
                 style="@style/Widget.AppCompat.Button.Colored"
-                android:id="@+id/log_blocked_exception"
-                android:layout_width="0dp"
-                android:layout_weight="1"
-                android:layout_height="wrap_content"
-                android:text="Report Blocked Exception"
-                android:backgroundTint="@android:color/holo_red_dark"
-                android:layout_gravity="center"/>
-
-            <Button
-                style="@style/Widget.AppCompat.Button.Colored"
-                android:id="@+id/track_analytic"
-                android:layout_width="0dp"
-                android:layout_weight="1"
-                android:layout_height="wrap_content"
-                android:text="Report Analytic Event"
-                android:backgroundTint="@android:color/holo_red_dark"
-                android:layout_gravity="center"/>
-
-        </LinearLayout>
-
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <Button
-                style="@style/Widget.AppCompat.Button.Colored"
                 android:id="@+id/user_report"
                 android:layout_width="0dp"
                 android:layout_weight="1"
@@ -156,11 +144,12 @@
 
             <Button
                 style="@style/Widget.AppCompat.Button.Colored"
-                android:id="@+id/dump_file_button"
+                android:id="@+id/log_blocked_exception"
                 android:layout_width="0dp"
                 android:layout_weight="1"
                 android:layout_height="wrap_content"
-                android:text="SHOW FILE DUMP"
+                android:text="Report Blocked Exception"
+                android:backgroundTint="@android:color/holo_red_dark"
                 android:layout_gravity="center"/>
 
         </LinearLayout>

--- a/steamclog/src/main/java/com/steamclock/steamclog/Steamclog.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/Steamclog.kt
@@ -109,41 +109,6 @@ object SteamcLog {
         Timber.log(logLevel.javaLevel, wrapper)
     }
 
-    // todo #64 Re-implement track method; was removed when we ported over to using Sentry
-//    fun track(@NonNls id: String, data: Map<String, Any?>) {
-//        if (!config.logLevel.analyticsEnabled) {
-//            logInternal(LogLevel.Info, "Anayltics not enabled ($id)")
-//            return
-//        }
-//
-//        if (config.firebaseAnalytics == null) {
-//            logInternal(LogLevel.Info, "Firebase analytics instance not set ($id)")
-//            return
-//        }
-//
-//        val bundle = Bundle()
-//        data.forEach { (key, value) ->
-//            when (value) {
-//                is Redactable -> {
-//                    bundle.putString(key, value.getRedactedDescription())
-//                }
-//                is Serializable -> {
-//                    bundle.putSerializable(key, value)
-//                }
-//                is Parcelable -> {
-//                    bundle.putParcelable(key, value)
-//                }
-//                else -> {
-//                    warn("Failed to encode $value to bundle, must be either parcelable, serializable or redactable")
-//                    return
-//                }
-//            }
-//        }
-//
-//        // Obtain the FirebaseAnalytics instance from the config.
-//        config.firebaseAnalytics?.apply { logEvent(id, bundle) }
-//    }
-
     //---------------------------------------------
     // Public util methods
     //---------------------------------------------


### PR DESCRIPTION
### Related Issue: #64


### Summary of Problem:
Long long time ago we kicked around the idea of having a "track" method for analytics, but it was never fully flushed out.  This PR is to clean up/remove the old commented out code that we won't be using.

### Proposed Solution:
Remove the code!

### Testing Steps:
Since this PR is just removing already commented out code (and a small shuffle to the sample app to remove the UXD button that was going to trigger the method) I don't think we need any actual testing done on this PR.
