### PR TITLE
[#117] Send Sentry report if file path given for logs is not valid

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,4 +62,6 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'com.google.android.material:material:1.6.1'
+    implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.4.0"
+    implementation "androidx.datastore:datastore-preferences:${versions.dataStore}"
 }

--- a/app/src/main/java/com/steamclock/steamclogsample/App.kt
+++ b/app/src/main/java/com/steamclock/steamclogsample/App.kt
@@ -1,7 +1,15 @@
 package com.steamclock.steamclogsample
 
 import android.app.Application
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.preferencesDataStore
 import com.steamclock.steamclog.*
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 
 /**
  * steamclog
@@ -10,13 +18,16 @@ import com.steamclock.steamclog.*
 class App : Application() {
     override fun onCreate() {
         super.onCreate()
-        clog.initWith(Config(
-            isDebug = BuildConfig.DEBUG,
-            fileWritePath = externalCacheDir,
-            autoRotateConfig = AutoRotateConfig(10L), // Short rotate so we can more easily test
-            filtering = appFiltering,
-            detailedLogsOnUserReports = true
-        ))
+        clog.initWith(
+            context = applicationContext,
+            config = Config(
+                isDebug = BuildConfig.DEBUG,
+                fileWritePath = externalCacheDir,
+                autoRotateConfig = AutoRotateConfig(10L), // Short rotate so we can more easily test
+                filtering = App.appFiltering,
+                detailedLogsOnUserReports = true
+            )
+        )
     }
 
     companion object {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -61,6 +61,12 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
 
+        <CheckBox
+            android:text="Force invalid file write path"
+            android:id="@+id/force_invalid_path_check"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
         <View
             android:layout_width="match_parent"
             android:layout_height="20dp" />

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,8 @@ buildscript {
         "compileSdk": 33,
         "kotlin": "1.8.10",
         "timber": "5.0.1",
-        "sentry": "6.23.0"
+        "sentry": "6.23.0",
+        "dataStore" : "1.0.0"
     ]
 
     repositories {

--- a/steamclog/build.gradle
+++ b/steamclog/build.gradle
@@ -64,4 +64,5 @@ dependencies {
     implementation "com.jakewharton.timber:timber:${versions.timber}"
     // https://github.com/getsentry/sentry-java/releases
     implementation "io.sentry:sentry-android:${versions.sentry}"
+    implementation "androidx.datastore:datastore-preferences:${versions.dataStore}"
 }

--- a/steamclog/src/main/java/com/steamclock/steamclog/SClogDataStore.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/SClogDataStore.kt
@@ -1,0 +1,32 @@
+package com.steamclock.steamclog
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.preferencesDataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+/**
+ * https://developer.android.com/topic/libraries/architecture/datastore
+ */
+class SClogDataStore(private val context: Context) {
+    companion object {
+        private val Context.SClogDataStore: DataStore<Preferences> by preferencesDataStore(name = "SClogDataStore")
+        private val hasReportedFilepathErrorKey = booleanPreferencesKey("has_logged_file_creation_failure")
+    }
+
+    /**
+     * hasReportedFilepathError indicates if Steamclog has reported a Sentry error regarding
+     * it's inability to use the given filePath to store logs.
+     */
+    val getHasReportedFilepathError: Flow<Boolean>
+        get() = context.SClogDataStore.data.map {
+            it[hasReportedFilepathErrorKey] ?: false
+        }
+    suspend fun setHasReportedFilepathError(value: Boolean) {
+        context.SClogDataStore.edit { it[hasReportedFilepathErrorKey] = value }
+    }
+}


### PR DESCRIPTION
### Related Issue: #117 


### Summary of Problem:
We are seeing issues where some of the standard file paths are not actually valid on some devices - and as such writes to these file locations are failing. We would like Steamclog to report when this is occurring for it's log files.

### Proposed Solution:
* If the file path given is null or does not exist, fire an error report to Sentry
* To avoid possible noisy reports for this issue, I have tried to use a DataStore to store a value that lets us know if we've already logged this issue.
* Sample app allows us to toggle between valid and invalid file paths

### Testing Steps:


### Screenshots: