### PR TITLE
[#127] Update dependencies to current stable versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on the Steamclock [Release Management Guide](https://github.com/steamclock/labs/wiki/Release-Management-Guide).
 
+## Jitpack v2.5 : Jun 10, 2026
+- Bumped compileSdk and targetSdk to 35, minSdk raised to 23
+- Updated AGP 8.5.2 → 8.13.2, Gradle wrapper 8.7 → 8.13
+- Updated Kotlin 2.0.0 → 2.4.0
+- Updated Sentry Android SDK 7.9.0 → 8.43.1, Sentry Gradle Plugin 4.5.1 → 6.10.0
+- Updated kotlinx-coroutines 1.9.0 → 1.11.0, appcompat 1.7.0 → 1.7.1, constraintlayout 2.2.0 → 2.2.1, material 1.12.0 → 1.14.0
+- Fixed Sentry 8.x API compatibility: clearUserId() and SentryEvent extras
+
+---
+
 ## Jitpack v2.4 : Aug 15, 2023
 - Allow more than one log to be attached to a Sentry report (#115)
 - Fixed issue with log auto rotation (#115)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on the Steamclock [Release Management Guide](https://github.com/steamclock/labs/wiki/Release-Management-Guide).
 
-## Jitpack v2.5 : Jun 10, 2026
+## [Unreleased] Jitpack v2.5 : [Add date after release]
 - Bumped compileSdk and targetSdk to 35, minSdk raised to 23
 - Updated AGP 8.5.2 → 8.13.2, Gradle wrapper 8.7 → 8.13
 - Updated Kotlin 2.0.0 → 2.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on the Steamclock [Release Management Guide](https://github.com/steamclock/labs/wiki/Release-Management-Guide).
 
-## [Unreleased] Jitpack v2.5 : [Add date after release]
+## Jitpack v2.5 : Unreleased
 - Bumped compileSdk and targetSdk to 35, minSdk raised to 23
 - Updated AGP 8.5.2 → 8.13.2, Gradle wrapper 8.7 → 8.13
 - Updated Kotlin 2.0.0 → 2.4.0

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ plugins {
     id 'com.android.application'
     id 'kotlin-android'
     // Provides auto-uploading of proguard mappings to Sentry
-    id 'io.sentry.android.gradle' version '4.5.1'
+    id 'io.sentry.android.gradle' version '6.10.0'
 }
 
 /**
@@ -34,7 +34,7 @@ android {
 
     defaultConfig {
         applicationId "com.steamclock.steamclogsample"
-        minSdkVersion 21
+        minSdkVersion 23
         targetSdkVersion versions.compileSdk
         versionCode 1
         versionName "1.0"
@@ -58,8 +58,8 @@ android {
 dependencies {
     implementation project(':steamclog')
     // Since Sentry is a dependency of steamclog, we do not have to import it again
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0'
-    implementation 'androidx.appcompat:appcompat:1.7.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.2.0'
-    implementation 'com.google.android.material:material:1.12.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.11.0'
+    implementation 'androidx.appcompat:appcompat:1.7.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
+    implementation 'com.google.android.material:material:1.14.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,10 @@
 buildscript {
 
     ext.versions = [
-        "compileSdk": 34,
-        "kotlin": "2.0.0",
+        "compileSdk": 35,
+        "kotlin": "2.4.0",
         "timber": "5.0.1",
-        "sentry": "7.9.0"
+        "sentry": "8.43.1"
     ]
 
     repositories {
@@ -14,7 +14,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.5.2'
+        classpath 'com.android.tools.build:gradle:8.13.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -26,6 +26,7 @@ allprojects {
         google()
         mavenCentral()
     }
+
 }
 
 task clean(type: Delete) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Aug 01 09:31:10 PDT 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/steamclog/build.gradle
+++ b/steamclog/build.gradle
@@ -32,15 +32,12 @@ android {
         singleVariant("release")
     }
 
-    // ADD COMPATIBILITY OPTIONS TO BE COMPATIBLE WITH JAVA 1.8
-    // Added for Sentry support
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+    kotlin {
+        jvmToolchain(17)
     }
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 23
         targetSdkVersion versions.compileSdk
         consumerProguardFiles "consumer-rules.pro"
     }

--- a/steamclog/src/main/java/com/steamclock/steamclog/Destinations.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/Destinations.kt
@@ -71,7 +71,7 @@ internal class SentryDestination : Timber.Tree() {
                     setMessage(originalMessage)
                     formatted = originalMessage
                 })
-                wrapper?.extraInfo?.let { extras = it }
+                wrapper?.extraInfo?.let { setExtras(it) }
             }
 
             // Attach log files if desired

--- a/steamclog/src/main/java/com/steamclock/steamclog/Steamclog.kt
+++ b/steamclog/src/main/java/com/steamclock/steamclog/Steamclog.kt
@@ -129,9 +129,7 @@ object SteamcLog {
     }
 
     fun clearUserId() {
-        Sentry.configureScope { scope ->
-            scope.user = null
-        }
+        Sentry.setUser(null)
     }
     
 //    fun setCustomKey(key: String, value: String) {


### PR DESCRIPTION
## Issue #127 
- Bumped all dependencies to current stable: compileSdk/targetSdk 35, minSdk 23, AGP 8.13.2, Gradle 8.13, Kotlin 2.4.0, Sentry Android 8.43.1 / Gradle Plugin 6.10.0, and AndroidX libs
- Fixed Sentry 8.x API compatibility: `clearUserId()` and `SentryEvent` extras assignment
- Added CHANGELOG entry for v2.5

## Test plan
- [x] Sync and build succeeds with no errors
- [x] Sample app runs in debug mode without `SC_CALL_STACK_INDEX` assertion firing
- [x] `clog.error()` and `clog.fatal()` appear in logcat with correct caller file/line tag
- [x] Errors appear in the Sentry dashboard (https://steamclock-software.sentry.io/issues/?project=5399932&statsPeriod=14d)
- [x] `clog.userReport()` attaches log files to the Sentry event
<img width="936" height="265" alt="image" src="https://github.com/user-attachments/assets/daabeedc-d81c-425a-adcb-2831d462a45f" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)